### PR TITLE
feat: Fix counters and add i18n for descriptions

### DIFF
--- a/data/silksong_items.json
+++ b/data/silksong_items.json
@@ -17,129 +17,1738 @@
     "tool"
   ],
   "items": [
-  {"id":"clawline","category":"ability","name":{"en":"Clawline","es":"Clawline"},"weight":1,"icon":"assets/images/abilities/clawline.png","location_text":"Effect: Fling needle as a harpoon with silk.","location_img":"assets/images/abilities_locations/clawline.jpg","numId":68,"image":"assets/images/abilities/clawline.png"},
-  {"id":"cling-grip","category":"ability","name":{"en":"Cling Grip","es":"Cling Grip"},"weight":1,"icon":"assets/images/abilities/cling_grip.png","location_text":"Effect: Wall-jump.","location_img":"assets/images/abilities_locations/cling_rip.jpg","numId":69,"image":"assets/images/abilities/cling_grip.png"},
-  {"id":"needle-strike","category":"ability","name":{"en":"Needle Strike","es":"Needle Strike"},"weight":1,"icon":"assets/images/abilities/needle_strike.png","location_text":"Effect: Charged attack.","location_img":"assets/images/abilities_locations/needle_strike.jpg","numId":70,"image":"assets/images/abilities/needle_strike.png"},
-  {"id":"needolin","category":"ability","name":{"en":"Needolin","es":"Needolin"},"weight":1,"icon":"assets/images/abilities/needolin.png","location_text":"Required: Defeat Widow. Effect: Play songs that can open special Needolin Doors, reveal secret lore, and make enemies / NPCs sing.","location_img":"assets/images/abilities_locations/needolin.jpg","numId":71,"image":"assets/images/abilities/needolin.png"},
-  {"id":"silk-soar","category":"ability","name":{"en":"Silk Soar","es":"Silk Soar"},"weight":1,"icon":"assets/images/abilities/silk_soar.png","location_text":"ACT 3: Effect: Fling upwards.","location_img":"assets/images/abilities_locations/silk_soar.jpg","numId":72,"image":"assets/images/abilities/silk_soar.png"},
-  {"id":"swift-step","category":"ability","name":{"en":"Swift Step","es":"Swift Step"},"weight":1,"icon":"assets/images/abilities/swift_step.png","location_text":"Effect: Sprint at blinding speed, beyond one's natural limits. Tip: You can press the sprint button while in the air to gain distance quickly.","location_img":"assets/images/abilities_locations/swift_step.jpg","numId":73,"image":"assets/images/abilities/swift_step.png"},
-  {"id":"cross-stitch","category":"silk_skill","name":{"en":"Cross Stitch","es":"Cross Stitch"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cross-stitch.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Phantom boss fight in the Exhaust Organ area of\n          Bilewater.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cross-stitch-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":54,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cross-stitch.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cross-stitch-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"pale-nails","category":"silk_skill","name":{"en":"Pale Nails","es":"Pale Nails"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pale-nails.png?fit=contain&h=22&w=22","location_text":"Bind Grand Mother Silk's arm at the top of The Cradle during Act 3.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pale-nails-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":55,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pale-nails.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pale-nails-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"sharpdart","category":"silk_skill","name":{"en":"Sharpdart","es":"Sharpdart"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sharpdart.png?fit=contain&h=22&w=22","location_text":"Bind the statue in the Weavenest Karn area to the west of the Wormways.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sharpdart-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":56,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sharpdart.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sharpdart-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"silkspear","category":"silk_skill","name":{"en":"Silkspear","es":"Silkspear"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspear.png?fit=contain&h=22&w=22","location_text":"Bind the statue in the Mosshome area of Moss Grotto.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspear-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":57,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspear.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspear-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"rune-rage","category":"silk_skill","name":{"en":"Rune Rage","es":"Rune Rage"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rune-rage.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the First Sinner boss fight at The Slab.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rune-rage-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":58,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rune-rage.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rune-rage-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"thread-storm","category":"silk_skill","name":{"en":"Thread Storm","es":"Thread Storm"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thread-storm.png?fit=contain&h=22&w=22","location_text":"Bind the statue in the Craw Lake area of Greymoor.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thread-storm-map-1.jpg?q=49&fit=crop&w=480&dpr=2","numId":59,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thread-storm.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thread-storm-map-1.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"sylphsong","category":"misc","name":{"en":"Sylphsong","es":"Sylphsong"},"weight":1,"location_text":null,"location_img":"https://cdn.wikimg.net/en/hkwiki/images/c/ce/Mapshot_SS_Eva_01.png","numId":46,"image":"assets/images/sylphsong.png","icon":"assets/images/sylphsong.png"},
-  {"id":"everbloom","category":"misc","name":{"en":"Everbloom","es":"Everbloom"},"weight":1,"location_text":"Given by the White Lady during the Red Memory.","location_img":null,"numId":47,"image":"assets/images/everbloom.png","icon":"assets/images/everbloom.png"},
-  {"id":"ascendants-grip","category":"tool","name":{"en":"Ascendant's Grip","es":"Ascendant's Grip"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-ascendants-grip.png?fit=contain&h=22&w=22","location_text":"Purchase from Jubilana in Songclave for 350 Rosaries after completing the The Wandering\n          Merchant Wish.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-ascendants-grip-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":74,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-ascendants-grip.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-ascendants-grip-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"barbed-bracelet","category":"tool","name":{"en":"Barbed Bracelet","es":"Barbed Bracelet"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-barbed-bracelet.png?fit=contain&h=22&w=22","location_text":"Found on a bug corpse in Sinner's Road.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-barbed-bracelet-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":75,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-barbed-bracelet.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-barbed-bracelet-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"claw-mirror-all","category":"tool","name":{"en":"Claw Mirror / Claw Mirrors","es":"Claw Mirror / Claw Mirrors"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-claw-mirror.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Trobbio boss fight in the Stage area of the\n          Whispering Vaults.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-claw-mirror-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":76,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-claw-mirror.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-claw-mirror-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"cogfly","category":"tool","name":{"en":"Cogfly","es":"Cogfly"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogfly.png?fit=contain&h=22&w=22","location_text":"Crafted at a table in the High Falls area. Requires one Craftmetal.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogfly-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":77,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogfly.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogfly-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"cogwork-wheel","category":"tool","name":{"en":"Cogwork Wheel","es":"Cogwork Wheel"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogwork-wheel.png?fit=contain&h=22&w=22","location_text":"Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 360\n          Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogwork-wheel-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":78,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogwork-wheel.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogwork-wheel-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"compass","category":"tool","name":{"en":"Compass","es":"Compass"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-compass.png?fit=contain&h=22&w=22","location_text":"Purchase from Shakra for 70 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-compass-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":79,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-compass.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-compass-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"conchcutter","category":"tool","name":{"en":"Conchcutter","es":"Conchcutter"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-conchcutter.png?fit=contain&h=22&w=22","location_text":"Found in the Coral Tower cave in the Sands of Karak area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-conchcutter-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":80,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-conchcutter.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-conchcutter-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"curveclaw-all","category":"tool","name":{"en":"Curveclaw / Curvesickle","es":"Curveclaw / Curvesickle"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-curveclaw.png?fit=contain&h=22&w=22","location_text":"Purchase from Mottled Skarr in the Hunter's March area for 140 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-curveclaw-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":81,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-curveclaw.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-curveclaw-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"dead-bugs-purse-all","category":"tool","name":{"en":"Dead Bug's Purse / Shell Satchel","es":"Dead Bug's Purse / Shell Satchel"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-dead-bugs-purse.png?fit=contain&h=22&w=22","location_text":"Found on a bug corpse in the Wormways area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-dead-bugs-purse-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":82,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-dead-bugs-purse.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-dead-bugs-purse-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"delvers-drill","category":"tool","name":{"en":"Delver's Drill","es":"Delver's Drill"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-delvers-drill.png?fit=contain&h=22&w=22","location_text":"Found on a table in the southwestern part of the Underworks area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-delvers-drill-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":83,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-delvers-drill.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-delvers-drill-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"druids-eye-all","category":"tool","name":{"en":"Druid's Eye / Druid's Eyes","es":"Druid's Eye / Druid's Eyes"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-druids-eye.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing\n          \n            the Berry Picking Wish\n          \n          for Moss Druid in the Moss Home area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-druids-eye-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":84,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-druids-eye.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-druids-eye-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"egg-of-flealia","category":"tool","name":{"en":"Egg of Flealia","es":"Egg of Flealia"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-egg-of-flealia.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing the Lost Fleas Wish for Fleamaster Mooshka in The\n          Marrow.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-egg-of-flealia-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":85,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-egg-of-flealia.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-egg-of-flealia-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"flea-brew","category":"tool","name":{"en":"Flea Brew","es":"Flea Brew"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flea-brew.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for finding five fleas for Fleamaster Mooshka in The Marrow.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flea-brew-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":86,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flea-brew.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flea-brew-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"flintslate","category":"tool","name":{"en":"Flintslate","es":"Flintslate"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flintslate.png?fit=contain&h=22&w=22","location_text":"Found on a table in the Deep Docks area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flintslate-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":87,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flintslate.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flintslate-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"fractured-mask","category":"tool","name":{"en":"Fractured Mask","es":"Fractured Mask"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-fractured-mask.png?fit=contain&h=22&w=22","location_text":"Purchase from Mottled Skarr in the Hunter's March area for 260 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-fractured-mask-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":88,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-fractured-mask.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-fractured-mask-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"injector-band","category":"tool","name":{"en":"Injector Band","es":"Injector Band"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-injector-band.png?fit=contain&h=22&w=22","location_text":"Found on a table in the Whiteward area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-injector-band-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":89,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-injector-band.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-injector-band-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"longclaw","category":"tool","name":{"en":"Longclaw","es":"Longclaw"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longclaw.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing the Broodfeast Wish for the Huntress in the Putrefied\n          Ducts area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longclaw-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":90,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longclaw.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longclaw-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"longpin","category":"tool","name":{"en":"Longpin","es":"Longpin"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longpin.png?fit=contain&h=22&w=22","location_text":"Found behind the pink wasp nest in the Shellwood area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longpin-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":91,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longpin.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longpin-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"magma-bell","category":"tool","name":{"en":"Magma Bell","es":"Magma Bell"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magma-bell.png?fit=contain&h=22&w=22","location_text":"Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 110\n          Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magma-bell-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":92,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magma-bell.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magma-bell-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"magnetite-brooch","category":"tool","name":{"en":"Magnetite Brooch","es":"Magnetite Brooch"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-brooch.png?fit=contain&h=22&w=22","location_text":"Purchase from Pebb in the Bonebottom area for 120 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-brooch-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":93,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-brooch.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-brooch-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"magnetite-dice","category":"tool","name":{"en":"Magnetite Dice","es":"Magnetite Dice"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-dice.png?fit=contain&h=22&w=22","location_text":"Repeatedly beat Lumble the Lucky while playing the Dice mini-game.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-dice-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":94,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-dice.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-dice-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"memory-crystal","category":"tool","name":{"en":"Memory Crystal","es":"Memory Crystal"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-memory-crystal.png?fit=contain&h=22&w=22","location_text":"Found behind a wall of ice in the Mount Fay area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-memory-crystal-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":95,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-memory-crystal.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-memory-crystal-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"multibinder","category":"tool","name":{"en":"Multibinder","es":"Multibinder"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-multibinder.png?fit=contain&h=22&w=22","location_text":"Purchase from Frey in the Bellheart area for 880 Rosaries after completing the My Missing\n          Courier Wish.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-multibinder-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":96,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-multibinder.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-multibinder-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"pin-badge","category":"tool","name":{"en":"Pin Badge","es":"Pin Badge"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pin-badge.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Pinstress boss fight in the Mount Fay area during Act\n          3.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pin-badge-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":97,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pin-badge.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pin-badge-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"pimpillo","category":"tool","name":{"en":"Pimpillo","es":"Pimpillo"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pimpillo.png?fit=contain&h=22&w=22","location_text":"Crafted at a table in the area above Yarnaby's bellhome in Greymoor. Requires one\n          Craftmetal.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pimpillo-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":98,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pimpillo.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pimpillo-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"plasmium-phial","category":"tool","name":{"en":"Plasmium Phial","es":"Plasmium Phial"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-plasmium-phial.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing the Alchemist's Assistant Wish for Alchemist Zylotol\n          in the Wormways area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-plasmium-phial-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":99,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-plasmium-phial.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-plasmium-phial-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"pollip-pouch","category":"tool","name":{"en":"Pollip Pouch","es":"Pollip Pouch"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pollip-pouch.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing\n          \n            the Rite of the Pollip Wish\n          \n          for Greyroot in the Shellwood area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pollip-pouch-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":100,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pollip-pouch.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pollip-pouch-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"quick-sling","category":"tool","name":{"en":"Quick Sling","es":"Quick Sling"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-quick-sling.png?fit=contain&h=22&w=22","location_text":"Found by breaking through a false ceiling in the Bilewater area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-quick-sling-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":101,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-quick-sling.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-quick-sling-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"reserve-bind","category":"tool","name":{"en":"Reserve Bind","es":"Reserve Bind"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-reserve-bind.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Second Sentinel boss fight in the southeastern part\n          of The Forum.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-reserve-bind-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":102,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-reserve-bind.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-reserve-bind-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"rosary-cannon","category":"tool","name":{"en":"Rosary Cannon","es":"Rosary Cannon"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rosary-cannon.png?fit=contain&h=22&w=22","location_text":"Found on a table in the Forum area of High Halls.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rosary-cannon-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":103,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rosary-cannon.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rosary-cannon-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"sawtooth-circlet","category":"tool","name":{"en":"Sawtooth Circlet","es":"Sawtooth Circlet"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sawtooth-circlet.png?fit=contain&h=22&w=22","location_text":"Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 230\n          Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sawtooth-circlet-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":104,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sawtooth-circlet.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sawtooth-circlet-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"scuttlebrace","category":"tool","name":{"en":"Scuttlebrace","es":"Scuttlebrace"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-scuttlebrace.png?fit=contain&h=22&w=22","location_text":"Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 140\n          Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-scuttlebrace-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":105,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-scuttlebrace.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-scuttlebrace-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"shard-pendant","category":"tool","name":{"en":"Shard Pendant","es":"Shard Pendant"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-shard-pendant.png?fit=contain&h=22&w=22","location_text":"Found on a table in The Marrow.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-shard-pendant-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":106,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-shard-pendant.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-shard-pendant-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"silkshot-all","category":"tool","name":{"en":"Silkshot (All Variants)","es":"Silkshot (All Variants)"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkshot.png?fit=contain&h=22&w=22","location_text":"Find the Ruined Tool in the southeastern part of Bilewater and then take it to Forge\n          Daughter in the Deep Docks area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkshot-i-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":107,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkshot.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkshot-i-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"silkspeed-anklets","category":"tool","name":{"en":"Silkspeed Anklets","es":"Silkspeed Anklets"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspeed-anklets.png?fit=contain&h=22&w=22","location_text":"Obtained after sprinting across the chamber in the Weavenest Cindril area of Far Fields.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspeed-anklets-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":108,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspeed-anklets.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspeed-anklets-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"snitch-pick","category":"tool","name":{"en":"Snitch Pick","es":"Snitch Pick"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-snitch-pick.png?fit=contain&h=22&w=22","location_text":"Purchase from Grindle in the Blasted Steps area for 740 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-snitch-pick-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":109,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-snitch-pick.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-snitch-pick-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"spider-strings","category":"tool","name":{"en":"Spider Strings","es":"Spider Strings"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spider-strings.png?fit=contain&h=22&w=22","location_text":"Purchase from Jubilana in Songclave for 320 Rosaries after completing the The Lost\n          Merchant Wish.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spider-strings-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":110,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spider-strings.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spider-strings-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"spool-extender","category":"tool","name":{"en":"Spool Extender","es":"Spool Extender"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spool-extender.png?fit=contain&h=22&w=22","location_text":"Purchase from Jubilana in Songclave for 720 Rosaries after completing the The Wandering\n          Merchant Wish.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spool-extender-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":111,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spool-extender.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spool-extender-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"sting-shard","category":"tool","name":{"en":"Sting Shard","es":"Sting Shard"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sting-shard.png?fit=contain&h=22&w=22","location_text":"Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 140\n          Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sting-shard-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":112,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sting-shard.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sting-shard-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"straight-pin","category":"tool","name":{"en":"Straight Pin","es":"Straight Pin"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-straight-pin.png?fit=contain&h=22&w=22","location_text":"Found on a table in the area above Grindle's cell in The Marrow.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-straight-pin-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":113,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-straight-pin.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-straight-pin-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"tacks","category":"tool","name":{"en":"Tacks","es":"Tacks"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-tacks.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for completing the Roach Guts Wish for Crull and Benjin in the\n          Sinner's Road area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-tacks-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":114,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-tacks.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-tacks-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"thiefs-mark","category":"tool","name":{"en":"Thief's Mark","es":"Thief's Mark"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thiefs-mark.png?fit=contain&h=22&w=22","location_text":"Purchase from Grindle in the Blasted Steps area for 350 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thiefs-mark-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":115,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thiefs-mark.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thiefs-mark-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"threefold-pin","category":"tool","name":{"en":"Threefold Pin","es":"Threefold Pin"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-threefold-pin.png?fit=contain&h=22&w=22","location_text":"Found in a secret cave above the Craw Lake area of Greymoor.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-threefold-pin-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":116,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-threefold-pin.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-threefold-pin-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"throwing-ring","category":"tool","name":{"en":"Throwing Ring","es":"Throwing Ring"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-throwing-ring.png?fit=contain&h=22&w=22","location_text":"Trigger the Trail's End Wish using the wishboard in Bellhart, then find Shakra in the most\n          northeasterly part of Bilewater.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-throwing-ring-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":117,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-throwing-ring.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-throwing-ring-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"volt-filament","category":"tool","name":{"en":"Volt Filament","es":"Volt Filament"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-volt-filament.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Voltvyrm boss fight in the Voltnest area of Sands of\n          Karak.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-volt-filament-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":118,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-volt-filament.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-volt-filament-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"voltvessels","category":"tool","name":{"en":"Voltvessels","es":"Voltvessels"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-voltvessels.png?fit=contain&h=22&w=22","location_text":"Found on a table in the northeastern part of the Memorium area during Act 3.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-voltvessels-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":119,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-voltvessels.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-voltvessels-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"warding-bell","category":"tool","name":{"en":"Warding Bell","es":"Warding Bell"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-warding-bell.png?fit=contain&h=22&w=22","location_text":"Found on a platform in the Far Fields area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-warding-bell-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":120,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-warding-bell.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-warding-bell-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"weavelight","category":"tool","name":{"en":"Weavelight","es":"Weavelight"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weavelight.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Moss Mothers boss fight in Weavenest Atla.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weavelight-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":121,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weavelight.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weavelight-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"weighted-belt","category":"tool","name":{"en":"Weighted Belt","es":"Weighted Belt"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weighted-belt.png?fit=contain&h=22&w=22","location_text":"Purchase from Mort in the Pilgrim's Rest area of Far Fields for 160 Rosaries.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weighted-belt-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":122,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weighted-belt.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weighted-belt-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"wispfire-lantern","category":"tool","name":{"en":"Wispfire Lantern","es":"Wispfire Lantern"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wispfire-lantern.png?fit=contain&h=22&w=22","location_text":"Obtained as a reward for beating the Father of the Flame boss fight in the section of\n          Bellheart to the west of Wisp Thicket.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wispfire-lantern-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":123,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wispfire-lantern.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wispfire-lantern-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"wreath-of-purity","category":"tool","name":{"en":"Wreath of Purity","es":"Wreath of Purity"},"weight":1,"icon":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wreath-of-purity.png?fit=contain&h=22&w=22","location_text":"Found on a platform in the Putrified Ducts area.","location_img":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wreath-of-purity-map.jpg?q=49&fit=crop&w=480&dpr=2","numId":124,"image":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wreath-of-purity.png?fit=contain&h=22&w=22","mapImage":"https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wreath-of-purity-map.jpg?q=49&fit=crop&w=480&dpr=2"},
-  {"id":"ancient-mask-shard-1-1","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 1/4 (Mask 1)","es":"Ancient Mask Shard 1/4 (Mask 1)"},"location_text":"Can be bought from Pebb for 300 rosaries","location_img":"assets/images/mask shards location/1.png","numId":5,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-1-2","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 2/4 (Mask 1)","es":"Ancient Mask Shard 2/4 (Mask 1)"},"location_text":"Required: Cling Grip","location_img":"assets/images/mask shards location/2.jpg","numId":6,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-1-3","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 3/4 (Mask 1)","es":"Ancient Mask Shard 3/4 (Mask 1)"},"location_text":"Required: Drifter's Cloak","location_img":"assets/images/mask shards location/3.jpg","numId":7,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-1-4","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 4/4 (Mask 1)","es":"Ancient Mask Shard 4/4 (Mask 1)"},"location_text":"Behind a breakable wall at the water's edge.","location_img":"assets/images/mask shards location/4.jpg","numId":8,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-2-1","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 1/4 (Mask 2)","es":"Ancient Mask Shard 1/4 (Mask 2)"},"location_text":"At the end of the platforming challenge in the room behind a Breakable Wall.\n\nNote: Taking it spawns a few Phacia enemies throughout the room.","location_img":"assets/images/mask shards location/5.jpg","numId":9,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-2-2","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 2/4 (Mask 2)","es":"Ancient Mask Shard 2/4 (Mask 2)"},"location_text":"On a high-up ledge in a room filled with lava.","location_img":"assets/images/mask shards location/6.jpg","numId":10,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-2-3","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 3/4 (Mask 2)","es":"Ancient Mask Shard 3/4 (Mask 2)"},"location_text":"Required: Silk Soar, or:\n\nSwift Step from the platform in the first screenshot above\nClawline immediately after\nFaydown Cloak to gain a bit more height","location_img":"assets/images/mask shards location/7.jpg","numId":11,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-2-4","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 4/4 (Mask 2)","es":"Ancient Mask Shard 4/4 (Mask 2)"},"location_text":"At the top of a tunnel reached after an Arena Battle.","location_img":"assets/images/mask shards location/8.jpg","numId":12,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-3-1","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 1/4 (Mask 3)","es":"Ancient Mask Shard 1/4 (Mask 3)"},"location_text":"Required: Hit the box in the corridor below, entered via Breakable Ceiling.","location_img":"assets/images/mask shards location/9.jpg","numId":13,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-3-2","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 2/4 (Mask 3)","es":"Ancient Mask Shard 2/4 (Mask 3)"},"location_text":"Required: Complete Savage Beastfly Wish","location_img":"assets/images/mask shards location/10.jpg","numId":14,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-3-3","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 3/4 (Mask 3)","es":"Ancient Mask Shard 3/4 (Mask 3)"},"location_text":"Required: At the top of the Skull Cavern. You'll need to reach the bottom before it becomes accessible.","location_img":"assets/images/mask shards location/11.jpg","numId":15,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-3-4","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 4/4 (Mask 3)","es":"Ancient Mask Shard 4/4 (Mask 3)"},"location_text":"At the end of a precarious series of corridors, filled with Slubberlug and parasite-infested waters.\n\nRequired: Clawline","location_img":"assets/images/mask shards location/12.jpg","numId":16,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-4-1","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 1/4 (Mask 4)","es":"Ancient Mask Shard 1/4 (Mask 4)"},"location_text":"Can be purchased from Jubilana for 750 Rosaries","location_img":"assets/images/mask shards location/13.jpg","numId":17,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-4-2","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 2/4 (Mask 4)","es":"Ancient Mask Shard 2/4 (Mask 4)"},"location_text":"At the top of a room behind the Locked Door - Apostate that holds a platforming challenge.\n\nEasiest to reach via Silk Soar.","location_img":"assets/images/mask shards location/14.jpg","numId":18,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-4-3","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 3/4 (Mask 4)","es":"Ancient Mask Shard 3/4 (Mask 4)"},"location_text":"Inside a large hollow cylinder.\n\nRequired: Faydown Cloak","location_img":"assets/images/mask shards location/15.jpg","numId":19,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-4-4","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 4/4 (Mask 4)","es":"Ancient Mask Shard 4/4 (Mask 4)"},"location_text":"Required: Faydown Cloak + Clawline\n\nAt the end of a platforming challenge.","location_img":"assets/images/mask shards location/16.jpg","numId":20,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-5-1","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 1/4 (Mask 5)","es":"Ancient Mask Shard 1/4 (Mask 5)"},"location_text":"Required: Complete Fastest in Pharloom Wish","location_img":"assets/images/mask shards location/17.jpg","numId":21,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-5-2","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 2/4 (Mask 5)","es":"Ancient Mask Shard 2/4 (Mask 5)"},"location_text":"Required: Complete The Hidden Hunter Wish in Act 3","location_img":"assets/images/mask shards location/18.jpg","numId":22,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-5-3","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 3/4 (Mask 5)","es":"Ancient Mask Shard 3/4 (Mask 5)"},"location_text":"Required: Complete Dark Hearts Wish in Act 3.","location_img":"assets/images/mask shards location/19.jpg","numId":23,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"ancient-mask-shard-5-4","category":"ancient_mask","weight":0.25,"name":{"en":"Ancient Mask Shard 4/4 (Mask 5)","es":"Ancient Mask Shard 4/4 (Mask 5)"},"location_text":"Can only be reached in ACT 3.\n\nAt the very top of the Brightvein. After a length platforming sequence, use Silk Soar to reach the room it's in.","location_img":"assets/images/mask shards location/20.jpg","numId":24,"image":"assets/images/shardmask.png","icon":"assets/images/shardmask.png"},
-  {"id":"silk-spool-1","category":"silk_spool","name":{"en":"Silk Spool Fragment 1","es":"Fragmento de Ovillo de Seda 1"},"weight":0.5,"location_text":"On a ledge reached by whacking the Lever at the edge of the magma-filled room. Keep jumping to avoid damage.","location_img":"assets/images/silk_spool_locations/1.jpg","numId":25,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-2","category":"silk_spool","name":{"en":"Silk Spool Fragment 2","es":"Fragmento de Ovillo de Seda 2"},"weight":0.5,"location_text":"In a boobytrapped room high above the settlement, reached by dropping through the Locked Trapdoor and following the path. Once you reach the Lever, continue to the right - and watch out for boobytraps.","location_img":"assets/images/silk_spool_locations/2.jpg","numId":26,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-3","category":"silk_spool","name":{"en":"Silk Spool Fragment 3","es":"Fragmento de Ovillo de Seda 3"},"weight":0.5,"location_text":"Required: Cling Grip. Tip: To reach this room, jump up the wall above this Breakable Wall.","location_img":"assets/images/silk_spool_locations/3.jpg","numId":27,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-4","category":"silk_spool","name":{"en":"Silk Spool Fragment 4","es":"Fragmento de Ovillo de Seda 4"},"weight":0.5,"location_text":"Required: Cling Grip.","location_img":"assets/images/silk_spool_locations/4.jpg","numId":28,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-5","category":"silk_spool","name":{"en":"Silk Spool Fragment 5","es":"Fragmento de Ovillo de Seda 5"},"weight":0.5,"location_text":"Required: Complete My Missing Courier. Can be purchased from Frey for 270 Rosaries.","location_img":"assets/images/silk_spool_locations/5.jpg","numId":29,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-6","category":"silk_spool","name":{"en":"Silk Spool Fragment 6","es":"Fragmento de Ovillo de Seda 6"},"weight":0.5,"location_text":"At the top of a frosty area. Required: Cling Grip.","location_img":"assets/images/silk_spool_locations/6.jpg","numId":30,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-7","category":"silk_spool","name":{"en":"Silk Spool Fragment 7","es":"Fragmento de Ovillo de Seda 7"},"weight":0.5,"location_text":"Sold by Grindle for 680 Rosaries.","location_img":"assets/images/silk_spool_locations/7.jpg","numId":31,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-8","category":"silk_spool","name":{"en":"Silk Spool Fragment 8","es":"Fragmento de Ovillo de Seda 8"},"weight":0.5,"location_text":"At the very top of the platforming puzzle in the room below. Tip: You can hit the bottom of the platforms to change their positions!","location_img":"assets/images/silk_spool_locations/8.jpg","numId":32,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-9","category":"silk_spool","name":{"en":"Silk Spool Fragment 9","es":"Fragmento de Ovillo de Seda 9"},"weight":0.5,"location_text":"In a room at the edge of the tunnels, initially entered here.","location_img":"assets/images/silk_spool_locations/9.jpg","numId":33,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-10","category":"silk_spool","name":{"en":"Silk Spool Fragment 10","es":"Fragmento de Ovillo de Seda 10"},"weight":0.5,"location_text":"Behind a Breakable Wall.","location_img":"assets/images/silk_spool_locations/10.jpg","numId":34,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-11","category":"silk_spool","name":{"en":"Silk Spool Fragment 11","es":"Fragmento de Ovillo de Seda 11"},"weight":0.5,"location_text":"Required: Find 14 Lost Fleas.","location_img":"assets/images/silk_spool_locations/11.jpg","numId":35,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-12","category":"silk_spool","name":{"en":"Silk Spool Fragment 12","es":"Fragmento de Ovillo de Seda 12"},"weight":0.5,"location_text":"At the end of a platforming sequence (starting elsewhere). Required: Clawline.","location_img":"assets/images/silk_spool_locations/12.jpg","numId":36,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-13","category":"silk_spool","name":{"en":"Silk Spool Fragment 13","es":"Fragmento de Ovillo de Seda 13"},"weight":0.5,"location_text":"Required: Faydown Cloak.","location_img":"assets/images/silk_spool_locations/13.jpg","numId":37,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-14","category":"silk_spool","name":{"en":"Silk Spool Fragment 14","es":"Fragmento de Ovillo de Seda 14"},"weight":0.5,"location_text":"Empty (no additional info).","location_img":"assets/images/silk_spool_locations/14.jpg","numId":38,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-15","category":"silk_spool","name":{"en":"Silk Spool Fragment 15","es":"Fragmento de Ovillo de Seda 15"},"weight":0.5,"location_text":"Required: Faydown Cloak + Clawline.","location_img":"assets/images/silk_spool_locations/15.jpg","numId":39,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-16","category":"silk_spool","name":{"en":"Silk Spool Fragment 16","es":"Fragmento de Ovillo de Seda 16"},"weight":0.5,"location_text":"Required: Complete Balm for The Wounded Wish.","location_img":"assets/images/silk_spool_locations/16.jpg","numId":40,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-17","category":"silk_spool","name":{"en":"Silk Spool Fragment 17","es":"Fragmento de Ovillo de Seda 17"},"weight":0.5,"location_text":"Required: Complete The Lost Merchant Wish. Can be purchased from Jubilana for 500 Rosaries.","location_img":"assets/images/silk_spool_locations/17.jpg","numId":41,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-spool-18","category":"silk_spool","name":{"en":"Silk Spool Fragment 18","es":"Fragmento de Ovillo de Seda 18"},"weight":0.5,"location_text":"Accessible once you've reached the Lever. Climb to the top floor, summon the elevator, then quickly slide back down the hole. Wait next to the lever for the elevator to pass, then jump down to find this spool fragment at the bottom.","location_img":"assets/images/silk_spool_locations/18.jpg","numId":42,"image":"assets/images/silkspool.png","icon":"assets/images/silkspool.png"},
-  {"id":"silk-heart-1","category":"silk_heart","name":{"en":"Silk Heart 1","es":"Silk Heart 1"},"weight":1,"location_text":"Defeat Bell Beast. Regain the power to regenerate Silk within one's shell.","location_img":"assets/images/silk hearts/1.jpg","numId":43,"image":"assets/images/silk_heart.png","icon":"assets/images/silk_heart.png"},
-  {"id":"silk-heart-2","category":"silk_heart","name":{"en":"Silk Heart 2","es":"Silk Heart 2"},"weight":1,"location_text":"Defeat The Unravelled.","location_img":"assets/images/silk hearts/2.jpg","numId":44,"image":"assets/images/silk_heart.png","icon":"assets/images/silk_heart.png"},
-  {"id":"silk-heart-3","category":"silk_heart","name":{"en":"Silk Heart 3","es":"Silk Heart 3"},"weight":1,"location_text":"Defeat Lace in The Cradle","location_img":"assets/images/silk hearts/3.jpg","numId":45,"image":"assets/images/silk_heart.png","icon":"assets/images/silk_heart.png"},
-  {"id":"crest-of-architect","category":"crest","name":{"en":"Crest of Architect","es":"Crest of Architect"},"weight":1,"location_text":"Required: Complete Chapel of the Architect","location_img":"assets/images/crests/location_architect.jpg","numId":48,"image":"assets/images/crests/crest_architect.png","icon":"assets/images/crests/crest_architect.png"},
-  {"id":"crest-of-beast","category":"crest","name":{"en":"Crest of Beast","es":"Crest of Beast"},"weight":1,"location_text":"Required: Complete Chapel of the Beast","location_img":"assets/images/crests/location_beast.jpg","numId":49,"image":"assets/images/crests/crest_beast.png","icon":"assets/images/crests/crest_beast.png"},
-  {"id":"crest-of-reaper","category":"crest","name":{"en":"Crest of Reaper","es":"Crest of Reaper"},"weight":1,"location_text":"Required: Defeat the ambush in the Chapel of the Reaper and climb to the top.","location_img":"assets/images/crests/location_reaper.jpg","numId":50,"image":"assets/images/crests/crest_reaper.png","icon":"assets/images/crests/crest_reaper.png"},
-  {"id":"crest-of-shaman","category":"crest","name":{"en":"Crest of Shaman","es":"Crest of Shaman"},"weight":1,"location_text":"ACT 3: In a tunnel above the Lore Tablet, Silk Soar required","location_img":"assets/images/crests/location_shaman.jpg","numId":51,"image":"assets/images/crests/crest_shaman.png","icon":"assets/images/crests/crest_shaman.png"},
-  {"id":"crest-of-wanderer","category":"crest","name":{"en":"Crest of Wanderer","es":"Crest of Wanderer"},"weight":1,"location_text":"Required: Complete Chapel of the Wanderer","location_img":"assets/images/crests/location_wanderer.jpg","numId":52,"image":"assets/images/crests/crest_wanderer.png","icon":"assets/images/crests/crest_wanderer.png"},
-  {"id":"crest-of-witch","category":"crest","name":{"en":"Crest of Witch","es":"Crest of Witch"},"weight":1,"location_text":"Required: Take Twisted Bud to Greyroot; Complete Rite of Rebirth Wish; Complete Infestation Operation Wish","location_img":"assets/images/crests/location_witch.jpg","numId":53,"image":"assets/images/crests/crest_witch.png","icon":"assets/images/crests/crest_witch.png"},
-  {"id":"crafting-kit-upgrade-1","category":"crafting_kit_upgrade","name":{"en":"Crafting Kit Upgrade 1","es":"Crafting Kit Upgrade 1"},"weight":1,"location_text":"Can be purchased from Forge Daughter for 180 Rosaries","location_img":"assets/images/craft_upgrades_locations/1.jpg","numId":60,"image":"assets/images/crafting_upgrade_kit.png","icon":"assets/images/crafting_upgrade_kit.png"},
-  {"id":"crafting-kit-upgrade-2","category":"crafting_kit_upgrade","name":{"en":"Crafting Kit Upgrade 2","es":"Crafting Kit Upgrade 2"},"weight":1,"location_text":"Complete Crawbug Clearing Wish","location_img":"assets/images/craft_upgrades_locations/2.jpg","numId":61,"image":"assets/images/crafting_upgrade_kit.png","icon":"assets/images/crafting_upgrade_kit.png"},
-  {"id":"crafting-kit-upgrade-3","category":"crafting_kit_upgrade","name":{"en":"Crafting Kit Upgrade 3","es":"Crafting Kit Upgrade 3"},"weight":1,"location_text":"Sold by Grindle for 700 Rosaries","location_img":"assets/images/craft_upgrades_locations/3.jpg","numId":62,"image":"assets/images/crafting_upgrade_kit.png","icon":"assets/images/crafting_upgrade_kit.png"},
-  {"id":"crafting-kit-upgrade-4","category":"crafting_kit_upgrade","name":{"en":"Crafting Kit Upgrade 4","es":"Crafting Kit Upgrade 4"},"weight":1,"location_text":"Purchased from Twelfth Architect for 450 Rosaries","location_img":"assets/images/craft_upgrades_locations/4.jpg","numId":63,"image":"assets/images/crafting_upgrade_kit.png","icon":"assets/images/crafting_upgrade_kit.png"},
-  {"id":"tool-pouch-upgrade-1","category":"tool_pouch_upgrade","name":{"en":"Tool Pouch Upgrade 1","es":"Tool Pouch Upgrade 1"},"weight":1,"location_text":"Can be purchased from Mort for 220 Rosaries","location_img":"assets/images/tool_pouch_locations/1.jpg","numId":64,"image":"assets/images/tool_pouch_upgrade.png","icon":"assets/images/tool_pouch_upgrade.png"},
-  {"id":"tool-pouch-upgrade-2","category":"tool_pouch_upgrade","name":{"en":"Tool Pouch Upgrade 2","es":"Tool Pouch Upgrade 2"},"weight":1,"location_text":"Complete Loddie's first challenge by hitting the target 15 times, or find it here in Act 3.","location_img":"assets/images/tool_pouch_locations/2.jpg","numId":65,"image":"assets/images/tool_pouch_upgrade.png","icon":"assets/images/tool_pouch_upgrade.png"},
-  {"id":"tool-pouch-upgrade-3","category":"tool_pouch_upgrade","name":{"en":"Tool Pouch Upgrade 3","es":"Tool Pouch Upgrade 3"},"weight":1,"location_text":"Complete Bugs of Pharloom Wish","location_img":"assets/images/tool_pouch_locations/3.jpg","numId":66,"image":"assets/images/tool_pouch_upgrade.png","icon":"assets/images/tool_pouch_upgrade.png"},
-  {"id":"tool-pouch-upgrade-4","category":"tool_pouch_upgrade","name":{"en":"Tool Pouch Upgrade 4","es":"Tool Pouch Upgrade 4"},"weight":1,"location_text":"Find 20 Lost Fleas in Pharloom","location_img":"assets/images/tool_pouch_locations/4.jpg","numId":67,"image":"assets/images/tool_pouch_upgrade.png","icon":"assets/images/tool_pouch_upgrade.png"},
-  {"id":"weapon-upgrade-sharpened","category":"needle_upgrade","name":{"en":"Sharpened Needle","es":"Sharpened Needle"},"weight":1,"location_text":"The first Hollow Knight: Silksong weapon upgrade comes from Pinmaster Plinney himself. He's located in the settlement of Bellhart, which is halfway between the regions of Greymoor and Shellwood.","location_img":"https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567251-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-1.jpg","numId":1,"image":"assets/images/needle.png","icon":"assets/images/needle.png"},
-  {"id":"weapon-upgrade-shining","category":"needle_upgrade","name":{"en":"Shining Needle","es":"Shining Needle"},"weight":1,"location_text":null,"location_img":"https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567252-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-2.jpg","numId":2,"image":"assets/images/needle.png","icon":"assets/images/needle.png"},
-  {"id":"weapon-upgrade-hivesteel","category":"needle_upgrade","name":{"en":"Hivesteel Needle","es":"Hivesteel Needle"},"weight":1,"location_text":null,"location_img":"https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567607-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-3.jpg","numId":3,"image":"assets/images/needle.png","icon":"assets/images/needle.png"},
-  {"id":"weapon-upgrade-pale-steel","category":"needle_upgrade","name":{"en":"Pale Steel Needle","es":"Pale Steel Needle"},"weight":1,"location_text":"The fourth and final Hollow Knight: Silksong weapon upgrade comes from Fleatopia. This is the most time-consuming activity since it's part of an over-arching objective: You must rescue all 30 Lost Fleas.","location_img":null,"numId":4,"image":"assets/images/needle.png","icon":"assets/images/needle.png"}
-    ]
+    {
+      "id": "clawline",
+      "category": "ability",
+      "name": { "en": "Clawline", "es": "Clawline" },
+      "weight": 1,
+      "icon": "assets/images/abilities/clawline.png",
+      "location_text": {
+        "en": "Effect: Fling needle as a harpoon with silk.",
+        "es": "Effect: Fling needle as a harpoon with silk."
+      },
+      "location_img": "assets/images/abilities_locations/clawline.jpg",
+      "numId": 68,
+      "image": "assets/images/abilities/clawline.png"
+    },
+    {
+      "id": "cling-grip",
+      "category": "ability",
+      "name": { "en": "Cling Grip", "es": "Cling Grip" },
+      "weight": 1,
+      "icon": "assets/images/abilities/cling_grip.png",
+      "location_text": { "en": "Effect: Wall-jump.", "es": "Effect: Wall-jump." },
+      "location_img": "assets/images/abilities_locations/cling_rip.jpg",
+      "numId": 69,
+      "image": "assets/images/abilities/cling_grip.png"
+    },
+    {
+      "id": "needle-strike",
+      "category": "ability",
+      "name": { "en": "Needle Strike", "es": "Needle Strike" },
+      "weight": 1,
+      "icon": "assets/images/abilities/needle_strike.png",
+      "location_text": { "en": "Effect: Charged attack.", "es": "Effect: Charged attack." },
+      "location_img": "assets/images/abilities_locations/needle_strike.jpg",
+      "numId": 70,
+      "image": "assets/images/abilities/needle_strike.png"
+    },
+    {
+      "id": "needolin",
+      "category": "ability",
+      "name": { "en": "Needolin", "es": "Needolin" },
+      "weight": 1,
+      "icon": "assets/images/abilities/needolin.png",
+      "location_text": {
+        "en": "Required: Defeat Widow. Effect: Play songs that can open special Needolin Doors, reveal secret lore, and make enemies / NPCs sing.",
+        "es": "Required: Defeat Widow. Effect: Play songs that can open special Needolin Doors, reveal secret lore, and make enemies / NPCs sing."
+      },
+      "location_img": "assets/images/abilities_locations/needolin.jpg",
+      "numId": 71,
+      "image": "assets/images/abilities/needolin.png"
+    },
+    {
+      "id": "silk-soar",
+      "category": "ability",
+      "name": { "en": "Silk Soar", "es": "Silk Soar" },
+      "weight": 1,
+      "icon": "assets/images/abilities/silk_soar.png",
+      "location_text": { "en": "ACT 3: Effect: Fling upwards.", "es": "ACT 3: Effect: Fling upwards." },
+      "location_img": "assets/images/abilities_locations/silk_soar.jpg",
+      "numId": 72,
+      "image": "assets/images/abilities/silk_soar.png"
+    },
+    {
+      "id": "swift-step",
+      "category": "ability",
+      "name": { "en": "Swift Step", "es": "Swift Step" },
+      "weight": 1,
+      "icon": "assets/images/abilities/swift_step.png",
+      "location_text": {
+        "en": "Effect: Sprint at blinding speed, beyond one's natural limits. Tip: You can press the sprint button while in the air to gain distance quickly.",
+        "es": "Effect: Sprint at blinding speed, beyond one's natural limits. Tip: You can press the sprint button while in the air to gain distance quickly."
+      },
+      "location_img": "assets/images/abilities_locations/swift_step.jpg",
+      "numId": 73,
+      "image": "assets/images/abilities/swift_step.png"
+    },
+    {
+      "id": "cross-stitch",
+      "category": "silk_skill",
+      "name": { "en": "Cross Stitch", "es": "Cross Stitch" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cross-stitch.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Phantom boss fight in the Exhaust Organ area of\n          Bilewater.",
+        "es": "Obtained as a reward for beating the Phantom boss fight in the Exhaust Organ area of\n          Bilewater."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cross-stitch-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 54,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cross-stitch.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cross-stitch-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "pale-nails",
+      "category": "silk_skill",
+      "name": { "en": "Pale Nails", "es": "Pale Nails" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pale-nails.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Bind Grand Mother Silk's arm at the top of The Cradle during Act 3.",
+        "es": "Bind Grand Mother Silk's arm at the top of The Cradle during Act 3."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pale-nails-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 55,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pale-nails.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pale-nails-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "sharpdart",
+      "category": "silk_skill",
+      "name": { "en": "Sharpdart", "es": "Sharpdart" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sharpdart.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Bind the statue in the Weavenest Karn area to the west of the Wormways.",
+        "es": "Bind the statue in the Weavenest Karn area to the west of the Wormways."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sharpdart-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 56,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sharpdart.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sharpdart-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "silkspear",
+      "category": "silk_skill",
+      "name": { "en": "Silkspear", "es": "Silkspear" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspear.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Bind the statue in the Mosshome area of Moss Grotto.",
+        "es": "Bind the statue in the Mosshome area of Moss Grotto."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspear-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 57,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspear.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspear-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "rune-rage",
+      "category": "silk_skill",
+      "name": { "en": "Rune Rage", "es": "Rune Rage" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rune-rage.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the First Sinner boss fight at The Slab.",
+        "es": "Obtained as a reward for beating the First Sinner boss fight at The Slab."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rune-rage-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 58,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rune-rage.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rune-rage-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "thread-storm",
+      "category": "silk_skill",
+      "name": { "en": "Thread Storm", "es": "Thread Storm" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thread-storm.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Bind the statue in the Craw Lake area of Greymoor.",
+        "es": "Bind the statue in the Craw Lake area of Greymoor."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thread-storm-map-1.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 59,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thread-storm.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thread-storm-map-1.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "sylphsong",
+      "category": "misc",
+      "name": { "en": "Sylphsong", "es": "Sylphsong" },
+      "weight": 1,
+      "location_text": null,
+      "location_img": "https://cdn.wikimg.net/en/hkwiki/images/c/ce/Mapshot_SS_Eva_01.png",
+      "numId": 46,
+      "image": "assets/images/sylphsong.png",
+      "icon": "assets/images/sylphsong.png"
+    },
+    {
+      "id": "everbloom",
+      "category": "misc",
+      "name": { "en": "Everbloom", "es": "Everbloom" },
+      "weight": 1,
+      "location_text": {
+        "en": "Given by the White Lady during the Red Memory.",
+        "es": "Given by the White Lady during the Red Memory."
+      },
+      "location_img": null,
+      "numId": 47,
+      "image": "assets/images/everbloom.png",
+      "icon": "assets/images/everbloom.png"
+    },
+    {
+      "id": "ascendants-grip",
+      "category": "tool",
+      "name": { "en": "Ascendant's Grip", "es": "Ascendant's Grip" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-ascendants-grip.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Jubilana in Songclave for 350 Rosaries after completing the The Wandering\n          Merchant Wish.",
+        "es": "Purchase from Jubilana in Songclave for 350 Rosaries after completing the The Wandering\n          Merchant Wish."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-ascendants-grip-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 74,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-ascendants-grip.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-ascendants-grip-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "barbed-bracelet",
+      "category": "tool",
+      "name": { "en": "Barbed Bracelet", "es": "Barbed Bracelet" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-barbed-bracelet.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a bug corpse in Sinner's Road.",
+        "es": "Found on a bug corpse in Sinner's Road."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-barbed-bracelet-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 75,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-barbed-bracelet.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-barbed-bracelet-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "claw-mirror-all",
+      "category": "tool",
+      "name": { "en": "Claw Mirror / Claw Mirrors", "es": "Claw Mirror / Claw Mirrors" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-claw-mirror.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Trobbio boss fight in the Stage area of the\n          Whispering Vaults.",
+        "es": "Obtained as a reward for beating the Trobbio boss fight in the Stage area of the\n          Whispering Vaults."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-claw-mirror-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 76,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-claw-mirror.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-claw-mirror-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "cogfly",
+      "category": "tool",
+      "name": { "en": "Cogfly", "es": "Cogfly" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogfly.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted at a table in the High Falls area. Requires one Craftmetal.",
+        "es": "Crafted at a table in the High Falls area. Requires one Craftmetal."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogfly-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 77,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogfly.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogfly-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "cogwork-wheel",
+      "category": "tool",
+      "name": { "en": "Cogwork Wheel", "es": "Cogwork Wheel" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogwork-wheel.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 360\n          Rosaries.",
+        "es": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 360\n          Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogwork-wheel-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 78,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-cogwork-wheel.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-cogwork-wheel-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "compass",
+      "category": "tool",
+      "name": { "en": "Compass", "es": "Compass" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-compass.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Shakra for 70 Rosaries.",
+        "es": "Purchase from Shakra for 70 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-compass-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 79,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-compass.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-compass-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "conchcutter",
+      "category": "tool",
+      "name": { "en": "Conchcutter", "es": "Conchcutter" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-conchcutter.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found in the Coral Tower cave in the Sands of Karak area.",
+        "es": "Found in the Coral Tower cave in the Sands of Karak area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-conchcutter-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 80,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-conchcutter.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-conchcutter-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "curveclaw-all",
+      "category": "tool",
+      "name": { "en": "Curveclaw / Curvesickle", "es": "Curveclaw / Curvesickle" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-curveclaw.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Mottled Skarr in the Hunter's March area for 140 Rosaries.",
+        "es": "Purchase from Mottled Skarr in the Hunter's March area for 140 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-curveclaw-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 81,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-curveclaw.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-curveclaw-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "dead-bugs-purse-all",
+      "category": "tool",
+      "name": { "en": "Dead Bug's Purse / Shell Satchel", "es": "Dead Bug's Purse / Shell Satchel" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-dead-bugs-purse.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a bug corpse in the Wormways area.",
+        "es": "Found on a bug corpse in the Wormways area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-dead-bugs-purse-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 82,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-dead-bugs-purse.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-dead-bugs-purse-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "delvers-drill",
+      "category": "tool",
+      "name": { "en": "Delver's Drill", "es": "Delver's Drill" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-delvers-drill.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the southwestern part of the Underworks area.",
+        "es": "Found on a table in the southwestern part of the Underworks area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-delvers-drill-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 83,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-delvers-drill.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-delvers-drill-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "druids-eye-all",
+      "category": "tool",
+      "name": { "en": "Druid's Eye / Druid's Eyes", "es": "Druid's Eye / Druid's Eyes" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-druids-eye.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing\n          \n            the Berry Picking Wish\n          \n          for Moss Druid in the Moss Home area.",
+        "es": "Obtained as a reward for completing\n          \n            the Berry Picking Wish\n          \n          for Moss Druid in the Moss Home area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-druids-eye-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 84,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-druids-eye.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-druids-eye-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "egg-of-flealia",
+      "category": "tool",
+      "name": { "en": "Egg of Flealia", "es": "Egg of Flealia" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-egg-of-flealia.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing the Lost Fleas Wish for Fleamaster Mooshka in The\n          Marrow.",
+        "es": "Obtained as a reward for completing the Lost Fleas Wish for Fleamaster Mooshka in The\n          Marrow."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-egg-of-flealia-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 85,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-egg-of-flealia.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-egg-of-flealia-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "flea-brew",
+      "category": "tool",
+      "name": { "en": "Flea Brew", "es": "Flea Brew" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flea-brew.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for finding five fleas for Fleamaster Mooshka in The Marrow.",
+        "es": "Obtained as a reward for finding five fleas for Fleamaster Mooshka in The Marrow."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flea-brew-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 86,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flea-brew.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flea-brew-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "flintslate",
+      "category": "tool",
+      "name": { "en": "Flintslate", "es": "Flintslate" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flintslate.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the Deep Docks area.",
+        "es": "Found on a table in the Deep Docks area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flintslate-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 87,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-flintslate.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-flintslate-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "fractured-mask",
+      "category": "tool",
+      "name": { "en": "Fractured Mask", "es": "Fractured Mask" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-fractured-mask.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Mottled Skarr in the Hunter's March area for 260 Rosaries.",
+        "es": "Purchase from Mottled Skarr in the Hunter's March area for 260 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-fractured-mask-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 88,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-fractured-mask.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-fractured-mask-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "injector-band",
+      "category": "tool",
+      "name": { "en": "Injector Band", "es": "Injector Band" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-injector-band.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the Whiteward area.",
+        "es": "Found on a table in the Whiteward area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-injector-band-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 89,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-injector-band.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-injector-band-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "longclaw",
+      "category": "tool",
+      "name": { "en": "Longclaw", "es": "Longclaw" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longclaw.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing the Broodfeast Wish for the Huntress in the Putrefied\n          Ducts area.",
+        "es": "Obtained as a reward for completing the Broodfeast Wish for the Huntress in the Putrefied\n          Ducts area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longclaw-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 90,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longclaw.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longclaw-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "longpin",
+      "category": "tool",
+      "name": { "en": "Longpin", "es": "Longpin" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longpin.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found behind the pink wasp nest in the Shellwood area.",
+        "es": "Found behind the pink wasp nest in the Shellwood area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longpin-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 91,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-longpin.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-longpin-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "magma-bell",
+      "category": "tool",
+      "name": { "en": "Magma Bell", "es": "Magma Bell" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magma-bell.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 110\n          Rosaries.",
+        "es": "Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 110\n          Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magma-bell-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 92,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magma-bell.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magma-bell-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "magnetite-brooch",
+      "category": "tool",
+      "name": { "en": "Magnetite Brooch", "es": "Magnetite Brooch" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-brooch.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Pebb in the Bonebottom area for 120 Rosaries.",
+        "es": "Purchase from Pebb in the Bonebottom area for 120 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-brooch-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 93,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-brooch.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-brooch-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "magnetite-dice",
+      "category": "tool",
+      "name": { "en": "Magnetite Dice", "es": "Magnetite Dice" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-dice.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Repeatedly beat Lumble the Lucky while playing the Dice mini-game.",
+        "es": "Repeatedly beat Lumble the Lucky while playing the Dice mini-game."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-dice-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 94,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-magnetite-dice.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-magnetite-dice-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "memory-crystal",
+      "category": "tool",
+      "name": { "en": "Memory Crystal", "es": "Memory Crystal" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-memory-crystal.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found behind a wall of ice in the Mount Fay area.",
+        "es": "Found behind a wall of ice in the Mount Fay area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-memory-crystal-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 95,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-memory-crystal.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-memory-crystal-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "multibinder",
+      "category": "tool",
+      "name": { "en": "Multibinder", "es": "Multibinder" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-multibinder.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Frey in the Bellheart area for 880 Rosaries after completing the My Missing\n          Courier Wish.",
+        "es": "Purchase from Frey in the Bellheart area for 880 Rosaries after completing the My Missing\n          Courier Wish."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-multibinder-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 96,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-multibinder.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-multibinder-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "pin-badge",
+      "category": "tool",
+      "name": { "en": "Pin Badge", "es": "Pin Badge" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pin-badge.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Pinstress boss fight in the Mount Fay area during Act\n          3.",
+        "es": "Obtained as a reward for beating the Pinstress boss fight in the Mount Fay area during Act\n          3."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pin-badge-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 97,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pin-badge.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pin-badge-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "pimpillo",
+      "category": "tool",
+      "name": { "en": "Pimpillo", "es": "Pimpillo" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pimpillo.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted at a table in the area above Yarnaby's bellhome in Greymoor. Requires one\n          Craftmetal.",
+        "es": "Crafted at a table in the area above Yarnaby's bellhome in Greymoor. Requires one\n          Craftmetal."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pimpillo-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 98,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pimpillo.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pimpillo-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "plasmium-phial",
+      "category": "tool",
+      "name": { "en": "Plasmium Phial", "es": "Plasmium Phial" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-plasmium-phial.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing the Alchemist's Assistant Wish for Alchemist Zylotol\n          in the Wormways area.",
+        "es": "Obtained as a reward for completing the Alchemist's Assistant Wish for Alchemist Zylotol\n          in the Wormways area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-plasmium-phial-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 99,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-plasmium-phial.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-plasmium-phial-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "pollip-pouch",
+      "category": "tool",
+      "name": { "en": "Pollip Pouch", "es": "Pollip Pouch" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pollip-pouch.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing\n          \n            the Rite of the Pollip Wish\n          \n          for Greyroot in the Shellwood area.",
+        "es": "Obtained as a reward for completing\n          \n            the Rite of the Pollip Wish\n          \n          for Greyroot in the Shellwood area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pollip-pouch-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 100,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-pollip-pouch.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-pollip-pouch-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "quick-sling",
+      "category": "tool",
+      "name": { "en": "Quick Sling", "es": "Quick Sling" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-quick-sling.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found by breaking through a false ceiling in the Bilewater area.",
+        "es": "Found by breaking through a false ceiling in the Bilewater area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-quick-sling-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 101,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-quick-sling.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-quick-sling-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "reserve-bind",
+      "category": "tool",
+      "name": { "en": "Reserve Bind", "es": "Reserve Bind" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-reserve-bind.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Second Sentinel boss fight in the southeastern part\n          of The Forum.",
+        "es": "Obtained as a reward for beating the Second Sentinel boss fight in the southeastern part\n          of The Forum."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-reserve-bind-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 102,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-reserve-bind.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-reserve-bind-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "rosary-cannon",
+      "category": "tool",
+      "name": { "en": "Rosary Cannon", "es": "Rosary Cannon" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rosary-cannon.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the Forum area of High Halls.",
+        "es": "Found on a table in the Forum area of High Halls."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rosary-cannon-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 103,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-rosary-cannon.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-rosary-cannon-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "sawtooth-circlet",
+      "category": "tool",
+      "name": { "en": "Sawtooth Circlet", "es": "Sawtooth Circlet" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sawtooth-circlet.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 230\n          Rosaries.",
+        "es": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 230\n          Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sawtooth-circlet-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 104,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sawtooth-circlet.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sawtooth-circlet-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "scuttlebrace",
+      "category": "tool",
+      "name": { "en": "Scuttlebrace", "es": "Scuttlebrace" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-scuttlebrace.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 140\n          Rosaries.",
+        "es": "Crafted by Twelfth Architect in the Underworks area. Requires one Craftmetal and 140\n          Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-scuttlebrace-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 105,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-scuttlebrace.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-scuttlebrace-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "shard-pendant",
+      "category": "tool",
+      "name": { "en": "Shard Pendant", "es": "Shard Pendant" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-shard-pendant.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in The Marrow.",
+        "es": "Found on a table in The Marrow."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-shard-pendant-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 106,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-shard-pendant.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-shard-pendant-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "silkshot-all",
+      "category": "tool",
+      "name": { "en": "Silkshot (All Variants)", "es": "Silkshot (All Variants)" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkshot.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Find the Ruined Tool in the southeastern part of Bilewater and then take it to Forge\n          Daughter in the Deep Docks area.",
+        "es": "Find the Ruined Tool in the southeastern part of Bilewater and then take it to Forge\n          Daughter in the Deep Docks area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkshot-i-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 107,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkshot.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkshot-i-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "silkspeed-anklets",
+      "category": "tool",
+      "name": { "en": "Silkspeed Anklets", "es": "Silkspeed Anklets" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspeed-anklets.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained after sprinting across the chamber in the Weavenest Cindril area of Far Fields.",
+        "es": "Obtained after sprinting across the chamber in the Weavenest Cindril area of Far Fields."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspeed-anklets-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 108,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-silkspeed-anklets.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-silkspeed-anklets-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "snitch-pick",
+      "category": "tool",
+      "name": { "en": "Snitch Pick", "es": "Snitch Pick" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-snitch-pick.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Grindle in the Blasted Steps area for 740 Rosaries.",
+        "es": "Purchase from Grindle in the Blasted Steps area for 740 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-snitch-pick-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 109,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-snitch-pick.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-snitch-pick-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "spider-strings",
+      "category": "tool",
+      "name": { "en": "Spider Strings", "es": "Spider Strings" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spider-strings.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Jubilana in Songclave for 320 Rosaries after completing the The Lost\n          Merchant Wish.",
+        "es": "Purchase from Jubilana in Songclave for 320 Rosaries after completing the The Lost\n          Merchant Wish."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spider-strings-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 110,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spider-strings.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spider-strings-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "spool-extender",
+      "category": "tool",
+      "name": { "en": "Spool Extender", "es": "Spool Extender" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spool-extender.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Jubilana in Songclave for 720 Rosaries after completing the The Wandering\n          Merchant Wish.",
+        "es": "Purchase from Jubilana in Songclave for 720 Rosaries after completing the The Wandering\n          Merchant Wish."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spool-extender-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 111,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-spool-extender.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-spool-extender-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "sting-shard",
+      "category": "tool",
+      "name": { "en": "Sting Shard", "es": "Sting Shard" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sting-shard.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 140\n          Rosaries.",
+        "es": "Crafted by Forge Daughter in the Deep Docks area. Requires one Craftmetal and 140\n          Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sting-shard-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 112,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-sting-shard.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-sting-shard-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "straight-pin",
+      "category": "tool",
+      "name": { "en": "Straight Pin", "es": "Straight Pin" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-straight-pin.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the area above Grindle's cell in The Marrow.",
+        "es": "Found on a table in the area above Grindle's cell in The Marrow."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-straight-pin-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 113,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-straight-pin.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-straight-pin-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "tacks",
+      "category": "tool",
+      "name": { "en": "Tacks", "es": "Tacks" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-tacks.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for completing the Roach Guts Wish for Crull and Benjin in the\n          Sinner's Road area.",
+        "es": "Obtained as a reward for completing the Roach Guts Wish for Crull and Benjin in the\n          Sinner's Road area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-tacks-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 114,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-tacks.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-tacks-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "thiefs-mark",
+      "category": "tool",
+      "name": { "en": "Thief's Mark", "es": "Thief's Mark" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thiefs-mark.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Grindle in the Blasted Steps area for 350 Rosaries.",
+        "es": "Purchase from Grindle in the Blasted Steps area for 350 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thiefs-mark-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 115,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-thiefs-mark.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-thiefs-mark-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "threefold-pin",
+      "category": "tool",
+      "name": { "en": "Threefold Pin", "es": "Threefold Pin" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-threefold-pin.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found in a secret cave above the Craw Lake area of Greymoor.",
+        "es": "Found in a secret cave above the Craw Lake area of Greymoor."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-threefold-pin-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 116,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-threefold-pin.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-threefold-pin-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "throwing-ring",
+      "category": "tool",
+      "name": { "en": "Throwing Ring", "es": "Throwing Ring" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-throwing-ring.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Trigger the Trail's End Wish using the wishboard in Bellhart, then find Shakra in the most\n          northeasterly part of Bilewater.",
+        "es": "Trigger the Trail's End Wish using the wishboard in Bellhart, then find Shakra in the most\n          northeasterly part of Bilewater."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-throwing-ring-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 117,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-throwing-ring.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-throwing-ring-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "volt-filament",
+      "category": "tool",
+      "name": { "en": "Volt Filament", "es": "Volt Filament" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-volt-filament.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Voltvyrm boss fight in the Voltnest area of Sands of\n          Karak.",
+        "es": "Obtained as a reward for beating the Voltvyrm boss fight in the Voltnest area of Sands of\n          Karak."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-volt-filament-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 118,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-volt-filament.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-volt-filament-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "voltvessels",
+      "category": "tool",
+      "name": { "en": "Voltvessels", "es": "Voltvessels" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-voltvessels.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a table in the northeastern part of the Memorium area during Act 3.",
+        "es": "Found on a table in the northeastern part of the Memorium area during Act 3."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-voltvessels-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 119,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-voltvessels.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-voltvessels-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "warding-bell",
+      "category": "tool",
+      "name": { "en": "Warding Bell", "es": "Warding Bell" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-warding-bell.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a platform in the Far Fields area.",
+        "es": "Found on a platform in the Far Fields area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-warding-bell-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 120,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-warding-bell.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-warding-bell-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "weavelight",
+      "category": "tool",
+      "name": { "en": "Weavelight", "es": "Weavelight" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weavelight.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Moss Mothers boss fight in Weavenest Atla.",
+        "es": "Obtained as a reward for beating the Moss Mothers boss fight in Weavenest Atla."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weavelight-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 121,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weavelight.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weavelight-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "weighted-belt",
+      "category": "tool",
+      "name": { "en": "Weighted Belt", "es": "Weighted Belt" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weighted-belt.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Purchase from Mort in the Pilgrim's Rest area of Far Fields for 160 Rosaries.",
+        "es": "Purchase from Mort in the Pilgrim's Rest area of Far Fields for 160 Rosaries."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weighted-belt-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 122,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-weighted-belt.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-weighted-belt-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "wispfire-lantern",
+      "category": "tool",
+      "name": { "en": "Wispfire Lantern", "es": "Wispfire Lantern" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wispfire-lantern.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Obtained as a reward for beating the Father of the Flame boss fight in the section of\n          Bellheart to the west of Wisp Thicket.",
+        "es": "Obtained as a reward for beating the Father of the Flame boss fight in the section of\n          Bellheart to the west of Wisp Thicket."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wispfire-lantern-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 123,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wispfire-lantern.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wispfire-lantern-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "wreath-of-purity",
+      "category": "tool",
+      "name": { "en": "Wreath of Purity", "es": "Wreath of Purity" },
+      "weight": 1,
+      "icon": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wreath-of-purity.png?fit=contain&h=22&w=22",
+      "location_text": {
+        "en": "Found on a platform in the Putrified Ducts area.",
+        "es": "Found on a platform in the Putrified Ducts area."
+      },
+      "location_img": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wreath-of-purity-map.jpg?q=49&fit=crop&w=480&dpr=2",
+      "numId": 124,
+      "image": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/all-hollow-knight-silksong-tools-wreath-of-purity.png?fit=contain&h=22&w=22",
+      "mapImage": "https://static0.gamerantimages.com/wordpress/wp-content/uploads/2025/09/silksong-tools-wreath-of-purity-map.jpg?q=49&fit=crop&w=480&dpr=2"
+    },
+    {
+      "id": "ancient-mask-shard-1-1",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 1/4 (Mask 1)", "es": "Ancient Mask Shard 1/4 (Mask 1)" },
+      "location_text": {
+        "en": "Can be bought from Pebb for 300 rosaries",
+        "es": "Can be bought from Pebb for 300 rosaries"
+      },
+      "location_img": "assets/images/mask shards location/1.png",
+      "numId": 5,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-1-2",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 2/4 (Mask 1)", "es": "Ancient Mask Shard 2/4 (Mask 1)" },
+      "location_text": { "en": "Required: Cling Grip", "es": "Required: Cling Grip" },
+      "location_img": "assets/images/mask shards location/2.jpg",
+      "numId": 6,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-1-3",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 3/4 (Mask 1)", "es": "Ancient Mask Shard 3/4 (Mask 1)" },
+      "location_text": { "en": "Required: Drifter's Cloak", "es": "Required: Drifter's Cloak" },
+      "location_img": "assets/images/mask shards location/3.jpg",
+      "numId": 7,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-1-4",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 4/4 (Mask 1)", "es": "Ancient Mask Shard 4/4 (Mask 1)" },
+      "location_text": {
+        "en": "Behind a breakable wall at the water's edge.",
+        "es": "Behind a breakable wall at the water's edge."
+      },
+      "location_img": "assets/images/mask shards location/4.jpg",
+      "numId": 8,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-2-1",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 1/4 (Mask 2)", "es": "Ancient Mask Shard 1/4 (Mask 2)" },
+      "location_text": {
+        "en": "At the end of the platforming challenge in the room behind a Breakable Wall.\n\nNote: Taking it spawns a few Phacia enemies throughout the room.",
+        "es": "At the end of the platforming challenge in the room behind a Breakable Wall.\n\nNote: Taking it spawns a few Phacia enemies throughout the room."
+      },
+      "location_img": "assets/images/mask shards location/5.jpg",
+      "numId": 9,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-2-2",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 2/4 (Mask 2)", "es": "Ancient Mask Shard 2/4 (Mask 2)" },
+      "location_text": {
+        "en": "On a high-up ledge in a room filled with lava.",
+        "es": "On a high-up ledge in a room filled with lava."
+      },
+      "location_img": "assets/images/mask shards location/6.jpg",
+      "numId": 10,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-2-3",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 3/4 (Mask 2)", "es": "Ancient Mask Shard 3/4 (Mask 2)" },
+      "location_text": {
+        "en": "Required: Silk Soar, or:\n\nSwift Step from the platform in the first screenshot above\nClawline immediately after\nFaydown Cloak to gain a bit more height",
+        "es": "Required: Silk Soar, or:\n\nSwift Step from the platform in the first screenshot above\nClawline immediately after\nFaydown Cloak to gain a bit more height"
+      },
+      "location_img": "assets/images/mask shards location/7.jpg",
+      "numId": 11,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-2-4",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 4/4 (Mask 2)", "es": "Ancient Mask Shard 4/4 (Mask 2)" },
+      "location_text": {
+        "en": "At the top of a tunnel reached after an Arena Battle.",
+        "es": "At the top of a tunnel reached after an Arena Battle."
+      },
+      "location_img": "assets/images/mask shards location/8.jpg",
+      "numId": 12,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-3-1",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 1/4 (Mask 3)", "es": "Ancient Mask Shard 1/4 (Mask 3)" },
+      "location_text": {
+        "en": "Required: Hit the box in the corridor below, entered via Breakable Ceiling.",
+        "es": "Required: Hit the box in the corridor below, entered via Breakable Ceiling."
+      },
+      "location_img": "assets/images/mask shards location/9.jpg",
+      "numId": 13,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-3-2",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 2/4 (Mask 3)", "es": "Ancient Mask Shard 2/4 (Mask 3)" },
+      "location_text": {
+        "en": "Required: Complete Savage Beastfly Wish",
+        "es": "Required: Complete Savage Beastfly Wish"
+      },
+      "location_img": "assets/images/mask shards location/10.jpg",
+      "numId": 14,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-3-3",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 3/4 (Mask 3)", "es": "Ancient Mask Shard 3/4 (Mask 3)" },
+      "location_text": {
+        "en": "Required: At the top of the Skull Cavern. You'll need to reach the bottom before it becomes accessible.",
+        "es": "Required: At the top of the Skull Cavern. You'll need to reach the bottom before it becomes accessible."
+      },
+      "location_img": "assets/images/mask shards location/11.jpg",
+      "numId": 15,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-3-4",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 4/4 (Mask 3)", "es": "Ancient Mask Shard 4/4 (Mask 3)" },
+      "location_text": {
+        "en": "At the end of a precarious series of corridors, filled with Slubberlug and parasite-infested waters.\n\nRequired: Clawline",
+        "es": "At the end of a precarious series of corridors, filled with Slubberlug and parasite-infested waters.\n\nRequired: Clawline"
+      },
+      "location_img": "assets/images/mask shards location/12.jpg",
+      "numId": 16,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-4-1",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 1/4 (Mask 4)", "es": "Ancient Mask Shard 1/4 (Mask 4)" },
+      "location_text": {
+        "en": "Can be purchased from Jubilana for 750 Rosaries",
+        "es": "Can be purchased from Jubilana for 750 Rosaries"
+      },
+      "location_img": "assets/images/mask shards location/13.jpg",
+      "numId": 17,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-4-2",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 2/4 (Mask 4)", "es": "Ancient Mask Shard 2/4 (Mask 4)" },
+      "location_text": {
+        "en": "At the top of a room behind the Locked Door - Apostate that holds a platforming challenge.\n\nEasiest to reach via Silk Soar.",
+        "es": "At the top of a room behind the Locked Door - Apostate that holds a platforming challenge.\n\nEasiest to reach via Silk Soar."
+      },
+      "location_img": "assets/images/mask shards location/14.jpg",
+      "numId": 18,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-4-3",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 3/4 (Mask 4)", "es": "Ancient Mask Shard 3/4 (Mask 4)" },
+      "location_text": {
+        "en": "Inside a large hollow cylinder.\n\nRequired: Faydown Cloak",
+        "es": "Inside a large hollow cylinder.\n\nRequired: Faydown Cloak"
+      },
+      "location_img": "assets/images/mask shards location/15.jpg",
+      "numId": 19,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-4-4",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 4/4 (Mask 4)", "es": "Ancient Mask Shard 4/4 (Mask 4)" },
+      "location_text": {
+        "en": "Required: Faydown Cloak + Clawline\n\nAt the end of a platforming challenge.",
+        "es": "Required: Faydown Cloak + Clawline\n\nAt the end of a platforming challenge."
+      },
+      "location_img": "assets/images/mask shards location/16.jpg",
+      "numId": 20,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-5-1",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 1/4 (Mask 5)", "es": "Ancient Mask Shard 1/4 (Mask 5)" },
+      "location_text": {
+        "en": "Required: Complete Fastest in Pharloom Wish",
+        "es": "Required: Complete Fastest in Pharloom Wish"
+      },
+      "location_img": "assets/images/mask shards location/17.jpg",
+      "numId": 21,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-5-2",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 2/4 (Mask 5)", "es": "Ancient Mask Shard 2/4 (Mask 5)" },
+      "location_text": {
+        "en": "Required: Complete The Hidden Hunter Wish in Act 3",
+        "es": "Required: Complete The Hidden Hunter Wish in Act 3"
+      },
+      "location_img": "assets/images/mask shards location/18.jpg",
+      "numId": 22,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-5-3",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 3/4 (Mask 5)", "es": "Ancient Mask Shard 3/4 (Mask 5)" },
+      "location_text": {
+        "en": "Required: Complete Dark Hearts Wish in Act 3.",
+        "es": "Required: Complete Dark Hearts Wish in Act 3."
+      },
+      "location_img": "assets/images/mask shards location/19.jpg",
+      "numId": 23,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "ancient-mask-shard-5-4",
+      "category": "ancient_mask",
+      "weight": 0.25,
+      "name": { "en": "Ancient Mask Shard 4/4 (Mask 5)", "es": "Ancient Mask Shard 4/4 (Mask 5)" },
+      "location_text": {
+        "en": "Can only be reached in ACT 3.\n\nAt the very top of the Brightvein. After a length platforming sequence, use Silk Soar to reach the room it's in.",
+        "es": "Can only be reached in ACT 3.\n\nAt the very top of the Brightvein. After a length platforming sequence, use Silk Soar to reach the room it's in."
+      },
+      "location_img": "assets/images/mask shards location/20.jpg",
+      "numId": 24,
+      "image": "assets/images/shardmask.png",
+      "icon": "assets/images/shardmask.png"
+    },
+    {
+      "id": "silk-spool-1",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 1", "es": "Fragmento de Ovillo de Seda 1" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "On a ledge reached by whacking the Lever at the edge of the magma-filled room. Keep jumping to avoid damage.",
+        "es": "On a ledge reached by whacking the Lever at the edge of the magma-filled room. Keep jumping to avoid damage."
+      },
+      "location_img": "assets/images/silk_spool_locations/1.jpg",
+      "numId": 25,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-2",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 2", "es": "Fragmento de Ovillo de Seda 2" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "In a boobytrapped room high above the settlement, reached by dropping through the Locked Trapdoor and following the path. Once you reach the Lever, continue to the right - and watch out for boobytraps.",
+        "es": "In a boobytrapped room high above the settlement, reached by dropping through the Locked Trapdoor and following the path. Once you reach the Lever, continue to the right - and watch out for boobytraps."
+      },
+      "location_img": "assets/images/silk_spool_locations/2.jpg",
+      "numId": 26,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-3",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 3", "es": "Fragmento de Ovillo de Seda 3" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Required: Cling Grip. Tip: To reach this room, jump up the wall above this Breakable Wall.",
+        "es": "Required: Cling Grip. Tip: To reach this room, jump up the wall above this Breakable Wall."
+      },
+      "location_img": "assets/images/silk_spool_locations/3.jpg",
+      "numId": 27,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-4",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 4", "es": "Fragmento de Ovillo de Seda 4" },
+      "weight": 0.5,
+      "location_text": { "en": "Required: Cling Grip.", "es": "Required: Cling Grip." },
+      "location_img": "assets/images/silk_spool_locations/4.jpg",
+      "numId": 28,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-5",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 5", "es": "Fragmento de Ovillo de Seda 5" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Required: Complete My Missing Courier. Can be purchased from Frey for 270 Rosaries.",
+        "es": "Required: Complete My Missing Courier. Can be purchased from Frey for 270 Rosaries."
+      },
+      "location_img": "assets/images/silk_spool_locations/5.jpg",
+      "numId": 29,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-6",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 6", "es": "Fragmento de Ovillo de Seda 6" },
+      "weight": 0.5,
+      "location_text": { "en": "At the top of a frosty area. Required: Cling Grip.", "es": "At the top of a frosty area. Required: Cling Grip." },
+      "location_img": "assets/images/silk_spool_locations/6.jpg",
+      "numId": 30,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-7",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 7", "es": "Fragmento de Ovillo de Seda 7" },
+      "weight": 0.5,
+      "location_text": { "en": "Sold by Grindle for 680 Rosaries.", "es": "Sold by Grindle for 680 Rosaries." },
+      "location_img": "assets/images/silk_spool_locations/7.jpg",
+      "numId": 31,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-8",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 8", "es": "Fragmento de Ovillo de Seda 8" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "At the very top of the platforming puzzle in the room below. Tip: You can hit the bottom of the platforms to change their positions!",
+        "es": "At the very top of the platforming puzzle in the room below. Tip: You can hit the bottom of the platforms to change their positions!"
+      },
+      "location_img": "assets/images/silk_spool_locations/8.jpg",
+      "numId": 32,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-9",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 9", "es": "Fragmento de Ovillo de Seda 9" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "In a room at the edge of the tunnels, initially entered here.",
+        "es": "In a room at the edge of the tunnels, initially entered here."
+      },
+      "location_img": "assets/images/silk_spool_locations/9.jpg",
+      "numId": 33,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-10",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 10", "es": "Fragmento de Ovillo de Seda 10" },
+      "weight": 0.5,
+      "location_text": { "en": "Behind a Breakable Wall.", "es": "Behind a Breakable Wall." },
+      "location_img": "assets/images/silk_spool_locations/10.jpg",
+      "numId": 34,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-11",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 11", "es": "Fragmento de Ovillo de Seda 11" },
+      "weight": 0.5,
+      "location_text": { "en": "Required: Find 14 Lost Fleas.", "es": "Required: Find 14 Lost Fleas." },
+      "location_img": "assets/images/silk_spool_locations/11.jpg",
+      "numId": 35,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-12",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 12", "es": "Fragmento de Ovillo de Seda 12" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "At the end of a platforming sequence (starting elsewhere). Required: Clawline.",
+        "es": "At the end of a platforming sequence (starting elsewhere). Required: Clawline."
+      },
+      "location_img": "assets/images/silk_spool_locations/12.jpg",
+      "numId": 36,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-13",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 13", "es": "Fragmento de Ovillo de Seda 13" },
+      "weight": 0.5,
+      "location_text": { "en": "Required: Faydown Cloak.", "es": "Required: Faydown Cloak." },
+      "location_img": "assets/images/silk_spool_locations/13.jpg",
+      "numId": 37,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-14",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 14", "es": "Fragmento de Ovillo de Seda 14" },
+      "weight": 0.5,
+      "location_text": { "en": "Empty (no additional info).", "es": "Empty (no additional info)." },
+      "location_img": "assets/images/silk_spool_locations/14.jpg",
+      "numId": 38,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-15",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 15", "es": "Fragmento de Ovillo de Seda 15" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Required: Faydown Cloak + Clawline.",
+        "es": "Required: Faydown Cloak + Clawline."
+      },
+      "location_img": "assets/images/silk_spool_locations/15.jpg",
+      "numId": 39,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-16",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 16", "es": "Fragmento de Ovillo de Seda 16" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Required: Complete Balm for The Wounded Wish.",
+        "es": "Required: Complete Balm for The Wounded Wish."
+      },
+      "location_img": "assets/images/silk_spool_locations/16.jpg",
+      "numId": 40,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-17",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 17", "es": "Fragmento de Ovillo de Seda 17" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Required: Complete The Lost Merchant Wish. Can be purchased from Jubilana for 500 Rosaries.",
+        "es": "Required: Complete The Lost Merchant Wish. Can be purchased from Jubilana for 500 Rosaries."
+      },
+      "location_img": "assets/images/silk_spool_locations/17.jpg",
+      "numId": 41,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-spool-18",
+      "category": "silk_spool",
+      "name": { "en": "Silk Spool Fragment 18", "es": "Fragmento de Ovillo de Seda 18" },
+      "weight": 0.5,
+      "location_text": {
+        "en": "Accessible once you've reached the Lever. Climb to the top floor, summon the elevator, then quickly slide back down the hole. Wait next to the lever for the elevator to pass, then jump down to find this spool fragment at the bottom.",
+        "es": "Accessible once you've reached the Lever. Climb to the top floor, summon the elevator, then quickly slide back down the hole. Wait next to the lever for the elevator to pass, then jump down to find this spool fragment at the bottom."
+      },
+      "location_img": "assets/images/silk_spool_locations/18.jpg",
+      "numId": 42,
+      "image": "assets/images/silkspool.png",
+      "icon": "assets/images/silkspool.png"
+    },
+    {
+      "id": "silk-heart-1",
+      "category": "silk_heart",
+      "name": { "en": "Silk Heart 1", "es": "Silk Heart 1" },
+      "weight": 1,
+      "location_text": {
+        "en": "Defeat Bell Beast. Regain the power to regenerate Silk within one's shell.",
+        "es": "Defeat Bell Beast. Regain the power to regenerate Silk within one's shell."
+      },
+      "location_img": "assets/images/silk hearts/1.jpg",
+      "numId": 43,
+      "image": "assets/images/silk_heart.png",
+      "icon": "assets/images/silk_heart.png"
+    },
+    {
+      "id": "silk-heart-2",
+      "category": "silk_heart",
+      "name": { "en": "Silk Heart 2", "es": "Silk Heart 2" },
+      "weight": 1,
+      "location_text": { "en": "Defeat The Unravelled.", "es": "Defeat The Unravelled." },
+      "location_img": "assets/images/silk hearts/2.jpg",
+      "numId": 44,
+      "image": "assets/images/silk_heart.png",
+      "icon": "assets/images/silk_heart.png"
+    },
+    {
+      "id": "silk-heart-3",
+      "category": "silk_heart",
+      "name": { "en": "Silk Heart 3", "es": "Silk Heart 3" },
+      "weight": 1,
+      "location_text": { "en": "Defeat Lace in The Cradle", "es": "Defeat Lace in The Cradle" },
+      "location_img": "assets/images/silk hearts/3.jpg",
+      "numId": 45,
+      "image": "assets/images/silk_heart.png",
+      "icon": "assets/images/silk_heart.png"
+    },
+    {
+      "id": "crest-of-architect",
+      "category": "crest",
+      "name": { "en": "Crest of Architect", "es": "Crest of Architect" },
+      "weight": 1,
+      "location_text": {
+        "en": "Required: Complete Chapel of the Architect",
+        "es": "Required: Complete Chapel of the Architect"
+      },
+      "location_img": "assets/images/crests/location_architect.jpg",
+      "numId": 48,
+      "image": "assets/images/crests/crest_architect.png",
+      "icon": "assets/images/crests/crest_architect.png"
+    },
+    {
+      "id": "crest-of-beast",
+      "category": "crest",
+      "name": { "en": "Crest of Beast", "es": "Crest of Beast" },
+      "weight": 1,
+      "location_text": {
+        "en": "Required: Complete Chapel of the Beast",
+        "es": "Required: Complete Chapel of the Beast"
+      },
+      "location_img": "assets/images/crests/location_beast.jpg",
+      "numId": 49,
+      "image": "assets/images/crests/crest_beast.png",
+      "icon": "assets/images/crests/crest_beast.png"
+    },
+    {
+      "id": "crest-of-reaper",
+      "category": "crest",
+      "name": { "en": "Crest of Reaper", "es": "Crest of Reaper" },
+      "weight": 1,
+      "location_text": {
+        "en": "Required: Defeat the ambush in the Chapel of the Reaper and climb to the top.",
+        "es": "Required: Defeat the ambush in the Chapel of the Reaper and climb to the top."
+      },
+      "location_img": "assets/images/crests/location_reaper.jpg",
+      "numId": 50,
+      "image": "assets/images/crests/crest_reaper.png",
+      "icon": "assets/images/crests/crest_reaper.png"
+    },
+    {
+      "id": "crest-of-shaman",
+      "category": "crest",
+      "name": { "en": "Crest of Shaman", "es": "Crest of Shaman" },
+      "weight": 1,
+      "location_text": {
+        "en": "ACT 3: In a tunnel above the Lore Tablet, Silk Soar required",
+        "es": "ACT 3: In a tunnel above the Lore Tablet, Silk Soar required"
+      },
+      "location_img": "assets/images/crests/location_shaman.jpg",
+      "numId": 51,
+      "image": "assets/images/crests/crest_shaman.png",
+      "icon": "assets/images/crests/crest_shaman.png"
+    },
+    {
+      "id": "crest-of-wanderer",
+      "category": "crest",
+      "name": { "en": "Crest of Wanderer", "es": "Crest of Wanderer" },
+      "weight": 1,
+      "location_text": {
+        "en": "Required: Complete Chapel of the Wanderer",
+        "es": "Required: Complete Chapel of the Wanderer"
+      },
+      "location_img": "assets/images/crests/location_wanderer.jpg",
+      "numId": 52,
+      "image": "assets/images/crests/crest_wanderer.png",
+      "icon": "assets/images/crests/crest_wanderer.png"
+    },
+    {
+      "id": "crest-of-witch",
+      "category": "crest",
+      "name": { "en": "Crest of Witch", "es": "Crest of Witch" },
+      "weight": 1,
+      "location_text": {
+        "en": "Required: Take Twisted Bud to Greyroot; Complete Rite of Rebirth Wish; Complete Infestation Operation Wish",
+        "es": "Required: Take Twisted Bud to Greyroot; Complete Rite of Rebirth Wish; Complete Infestation Operation Wish"
+      },
+      "location_img": "assets/images/crests/location_witch.jpg",
+      "numId": 53,
+      "image": "assets/images/crests/crest_witch.png",
+      "icon": "assets/images/crests/crest_witch.png"
+    },
+    {
+      "id": "crafting-kit-upgrade-1",
+      "category": "crafting_kit_upgrade",
+      "name": { "en": "Crafting Kit Upgrade 1", "es": "Crafting Kit Upgrade 1" },
+      "weight": 1,
+      "location_text": {
+        "en": "Can be purchased from Forge Daughter for 180 Rosaries",
+        "es": "Can be purchased from Forge Daughter for 180 Rosaries"
+      },
+      "location_img": "assets/images/craft_upgrades_locations/1.jpg",
+      "numId": 60,
+      "image": "assets/images/crafting_upgrade_kit.png",
+      "icon": "assets/images/crafting_upgrade_kit.png"
+    },
+    {
+      "id": "crafting-kit-upgrade-2",
+      "category": "crafting_kit_upgrade",
+      "name": { "en": "Crafting Kit Upgrade 2", "es": "Crafting Kit Upgrade 2" },
+      "weight": 1,
+      "location_text": {
+        "en": "Complete Crawbug Clearing Wish",
+        "es": "Complete Crawbug Clearing Wish"
+      },
+      "location_img": "assets/images/craft_upgrades_locations/2.jpg",
+      "numId": 61,
+      "image": "assets/images/crafting_upgrade_kit.png",
+      "icon": "assets/images/crafting_upgrade_kit.png"
+    },
+    {
+      "id": "crafting-kit-upgrade-3",
+      "category": "crafting_kit_upgrade",
+      "name": { "en": "Crafting Kit Upgrade 3", "es": "Crafting Kit Upgrade 3" },
+      "weight": 1,
+      "location_text": { "en": "Sold by Grindle for 700 Rosaries", "es": "Sold by Grindle for 700 Rosaries" },
+      "location_img": "assets/images/craft_upgrades_locations/3.jpg",
+      "numId": 62,
+      "image": "assets/images/crafting_upgrade_kit.png",
+      "icon": "assets/images/crafting_upgrade_kit.png"
+    },
+    {
+      "id": "crafting-kit-upgrade-4",
+      "category": "crafting_kit_upgrade",
+      "name": { "en": "Crafting Kit Upgrade 4", "es": "Crafting Kit Upgrade 4" },
+      "weight": 1,
+      "location_text": {
+        "en": "Purchased from Twelfth Architect for 450 Rosaries",
+        "es": "Purchased from Twelfth Architect for 450 Rosaries"
+      },
+      "location_img": "assets/images/craft_upgrades_locations/4.jpg",
+      "numId": 63,
+      "image": "assets/images/crafting_upgrade_kit.png",
+      "icon": "assets/images/crafting_upgrade_kit.png"
+    },
+    {
+      "id": "tool-pouch-upgrade-1",
+      "category": "tool_pouch_upgrade",
+      "name": { "en": "Tool Pouch Upgrade 1", "es": "Tool Pouch Upgrade 1" },
+      "weight": 1,
+      "location_text": {
+        "en": "Can be purchased from Mort for 220 Rosaries",
+        "es": "Can be purchased from Mort for 220 Rosaries"
+      },
+      "location_img": "assets/images/tool_pouch_locations/1.jpg",
+      "numId": 64,
+      "image": "assets/images/tool_pouch_upgrade.png",
+      "icon": "assets/images/tool_pouch_upgrade.png"
+    },
+    {
+      "id": "tool-pouch-upgrade-2",
+      "category": "tool_pouch_upgrade",
+      "name": { "en": "Tool Pouch Upgrade 2", "es": "Tool Pouch Upgrade 2" },
+      "weight": 1,
+      "location_text": {
+        "en": "Complete Loddie's first challenge by hitting the target 15 times, or find it here in Act 3.",
+        "es": "Complete Loddie's first challenge by hitting the target 15 times, or find it here in Act 3."
+      },
+      "location_img": "assets/images/tool_pouch_locations/2.jpg",
+      "numId": 65,
+      "image": "assets/images/tool_pouch_upgrade.png",
+      "icon": "assets/images/tool_pouch_upgrade.png"
+    },
+    {
+      "id": "tool-pouch-upgrade-3",
+      "category": "tool_pouch_upgrade",
+      "name": { "en": "Tool Pouch Upgrade 3", "es": "Tool Pouch Upgrade 3" },
+      "weight": 1,
+      "location_text": { "en": "Complete Bugs of Pharloom Wish", "es": "Complete Bugs of Pharloom Wish" },
+      "location_img": "assets/images/tool_pouch_locations/3.jpg",
+      "numId": 66,
+      "image": "assets/images/tool_pouch_upgrade.png",
+      "icon": "assets/images/tool_pouch_upgrade.png"
+    },
+    {
+      "id": "tool-pouch-upgrade-4",
+      "category": "tool_pouch_upgrade",
+      "name": { "en": "Tool Pouch Upgrade 4", "es": "Tool Pouch Upgrade 4" },
+      "weight": 1,
+      "location_text": { "en": "Find 20 Lost Fleas in Pharloom", "es": "Find 20 Lost Fleas in Pharloom" },
+      "location_img": "assets/images/tool_pouch_locations/4.jpg",
+      "numId": 67,
+      "image": "assets/images/tool_pouch_upgrade.png",
+      "icon": "assets/images/tool_pouch_upgrade.png"
+    },
+    {
+      "id": "weapon-upgrade-sharpened",
+      "category": "needle_upgrade",
+      "name": { "en": "Sharpened Needle", "es": "Sharpened Needle" },
+      "weight": 1,
+      "location_text": {
+        "en": "The first Hollow Knight: Silksong weapon upgrade comes from Pinmaster Plinney himself. He's located in the settlement of Bellhart, which is halfway between the regions of Greymoor and Shellwood.",
+        "es": "The first Hollow Knight: Silksong weapon upgrade comes from Pinmaster Plinney himself. He's located in the settlement of Bellhart, which is halfway between the regions of Greymoor and Shellwood."
+      },
+      "location_img": "https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567251-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-1.jpg",
+      "numId": 1,
+      "image": "assets/images/needle.png",
+      "icon": "assets/images/needle.png"
+    },
+    {
+      "id": "weapon-upgrade-shining",
+      "category": "needle_upgrade",
+      "name": { "en": "Shining Needle", "es": "Shining Needle" },
+      "weight": 1,
+      "location_text": null,
+      "location_img": "https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567252-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-2.jpg",
+      "numId": 2,
+      "image": "assets/images/needle.png",
+      "icon": "assets/images/needle.png"
+    },
+    {
+      "id": "weapon-upgrade-hivesteel",
+      "category": "needle_upgrade",
+      "name": { "en": "Hivesteel Needle", "es": "Hivesteel Needle" },
+      "weight": 1,
+      "location_text": null,
+      "location_img": "https://www.gamespot.com/a/uploads/scale_super/1816/18167535/4567607-hollow-knight-silksong-pale-oil-weapon-upgrades-guide-3.jpg",
+      "numId": 3,
+      "image": "assets/images/needle.png",
+      "icon": "assets/images/needle.png"
+    },
+    {
+      "id": "weapon-upgrade-pale-steel",
+      "category": "needle_upgrade",
+      "name": { "en": "Pale Steel Needle", "es": "Pale Steel Needle" },
+      "weight": 1,
+      "location_text": {
+        "en": "The fourth and final Hollow Knight: Silksong weapon upgrade comes from Fleatopia. This is the most time-consuming activity since it's part of an over-arching objective: You must rescue all 30 Lost Fleas.",
+        "es": "The fourth and final Hollow Knight: Silksong weapon upgrade comes from Fleatopia. This is the most time-consuming activity since it's part of an over-arching objective: You must rescue all 30 Lost Fleas."
+      },
+      "location_img": null,
+      "numId": 4,
+      "image": "assets/images/needle.png",
+      "icon": "assets/images/needle.png"
+    }
+  ]
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -7,7 +7,8 @@
   "footer.note": "Dataset enriquecido con info pública actual de Silksong (los pesos suman 100%).",
   "done.label": "Completado",
   "items.remaining.singular": "1 ítem restante",
-  "items.remaining.plural": "{n} ítems restantes"
-  ,"export.data":"Exportar Datos"
-  ,"import.data":"Importar Datos"
+  "items.remaining.plural": "{n} ítems restantes",
+  "export.data": "Exportar Datos",
+  "import.data": "Importar Datos",
+  "dataset.errors.title": "Problemas de validación del dataset:"
 }


### PR DESCRIPTION
This commit addresses two main issues: a critical bug that caused category-specific progress counters to be broken, and the lack of full internationalization support for item descriptions.

The key changes include:

- **Bugfix: Category Counters:**
  - The `updateCategoryCounts` function in `ui.js` has been rewritten to calculate progress directly from the data model instead of relying on inefficient and buggy DOM queries.
  - The function is now correctly called from all relevant parts of the application (`main.js` and `ui.js`) with the necessary `items` and `progress` data.
  - The category counters are now visible by default and update correctly when items are checked/unchecked or when the progress is reset.

- **Feature: Spanish Translation:**
  - The `data/silksong_items.json` data structure has been updated to support translatable `location_text`, changing it from a string to an `en`/`es` object.
  - The rendering logic in `ui.js` has been updated to display the correct language for both item names and descriptions based on the active locale.
  - The `main.js` file has been refactored to re-render the item list when the language is changed, ensuring that translations are applied immediately.
  - The Spanish translation file (`src/i18n/es.json`) has been updated with missing UI strings.

- **Refactoring:**
  - The rendering logic in `main.js` was centralized into a `rerenderList` function to improve code maintainability and ensure consistent updates across different user actions (search, language change, reset).