### PR TITLE
Fix: Replace blurry image flags with Unicode emojis

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,31 +190,7 @@
   /* Reset icon */
   #resetBtn { position:relative; padding-left:1.4rem; }
   #resetBtn::before { content:"↺"; position:absolute; left:.55rem; top:50%; transform:translateY(-52%); font-size:.7rem; opacity:.85; }
-  /* Guide button icon handled via own markup; language flags for select */
-  /* Removed flag styling: revert to simple select */
-  #langSel.flagged { background:none!important; }
   button:hover, #langSel:hover { border-color:var(--accent); }
-  .lang-container { position: relative; }
-  #langContainer::before {
-    content: '';
-    position: absolute;
-    left: 8px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 20px;
-    height: 15px;
-    background-size: contain;
-    background-repeat: no-repeat;
-    pointer-events: none;
-  }
-  #langSel { padding-left: 34px; }
-  #langContainer.en::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLXVzIiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPHBhdGggZmlsbD0iI2JkM2Q0NCIgZD0iTTAgMGg2NDB2NDgwSDAiLz4KICA8cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS13aWR0aD0iMzciIGQ9Ik0wIDU1LjNoNjQwTTAgMTI5aDY0ME0wIDIwM2g2NDBNMCAyNzdoNjQwTTAgMzUxaDY0ME0wIDQyNWg2NDAiLz4KICA8cGF0aCBmaWxsPSIjMTkyZjVkIiBkPSJNMCAwaDM2NC44djI1OC41SDAiLz4KICA8bWFya2VyIGlkPSJ1cy1hIiBtYXJrZXJIZWlnaHQ9IjMwIiBtYXJrZXJXaWR0aD0iMzAiPgogICAgPHBhdGggZmlsbD0iI2ZmZiIgZD0ibTE0IDAgOSAyN0wwIDEwaDI4TDUgMjdaIi8+CiAgPC9tYXJrZXI+CiAgPHBhdGggZmlsbD0ibm9uZSIgbWFya2VyLW1pZD0idXJsKCN1cy1hKSIgZD0ibTAgMCAxNiAxMWg2MSA2MSA2MSA2MSA2MEw0NyAzN2g2MSA2MSA2MCA2MUwxNiA2M2g2MSA2MSA2MSA2MSA2MEw0NyA4OWg2MSA2MSA2MCA2MUwxNiAxMTVoNjEgNjEgNjEgNjEgNjBMNDcgMTQxaDYxIDYxIDYwIDYxTDE2IDE2Nmg2MSA2MSA2MSA2MSA2MEw0NyAxOTJoNjEgNjEgNjAgNjFMMTYgMjE4aDYxIDYxIDYxIDYxIDYweiIvPgo8L3N2Zz4='); }
-  #langContainer.es::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLWVzIiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPHBhdGggZmlsbD0iI0FBMUUyQiIgZD0iTTAgMGg2NDB2NDgwSDB6Ii8+CiAgPHBhdGggZmlsbD0iI0ZGRkYwMCIgZD0iTTAgMTIwaDY0MHYyNDBIMHoiLz4KPC9zdmc+'); }
-  #langContainer.fr::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLWZyIiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgMGg2NDB2NDgwSDAiLz4KICA8cGF0aCBmaWxsPSIjMDAwMDkxIiBkPSJNMCAwaDIxMy4zdjQ4MEgweiIvPgogIDxwYXRoIGZpbGw9IiNlMTAwMGYiIGQ9Ik00MjYuNyAwSDY0MHY0ODBINDQyNi43eiIvPgo8L3N2Zz4='); }
-  #langContainer.de::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLWRlIiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPHBhdGggZmlsbD0iI2ZjMCIgZD0iTTAgMzIwaDY0MHYxNjBIMHoiLz4KICA8cGF0aCBmaWxsPSIjMDAwMDAxIiBkPSJNMCAwaDY0MHYxNjBIMHoiLz4KICA8cGF0aCBmaWxsPSJyZWQiIGQ9Ik0wIDE2MGg2NDB2MTYwSDB6Ii8+Cjwvc3ZnPg=='); }
-  #langContainer.it::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLWl0IiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPGcgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2Utd2lkdGg9IjFwdCI+CiAgICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMCAwaDY0MHY0ODBIMHoiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDkyNDYiIGQ9Ik0wIDBoMjEzLjN2NDgwSDB6Ii8+CiAgICA8cGF0aCBmaWxsPSIjY2UyYjM3IiBkPSJNNDI2LjcgMEg2NDB2NDgwSDQyNi43eiIvPgogIDwvZz4KPC9zdmc+'); }
-  #langContainer.ru::before { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJmbGFnLWljb25zLXJ1IiB2aWV3Qm94PSIwIDAgNjQwIDQ4MCI+CiAgPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgMGg2NDB2MTYwSDB6Ii8+CiAgPHBhdGggZmlsbD0iIzAwMzlhNiIgZD0iTTAgMTYwaDY0MHYxNjBIMHoiLz4KICA8cGF0aCBmaWxsPSIjZDUyYjFlIiBkPSJNMCAzMjBoNjQwdjE2MEgweiIvPgo8L3N2Zz4='); }
-  /* #resetBtn additional overrides can go here if needed */
     main { max-width:1400px; margin:0 auto; padding:0.75rem 1rem 2rem; }
     .categories { display:flex; flex-direction:column; gap:1rem; }
     .cat { background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); overflow:hidden; }
@@ -274,15 +250,15 @@
 <header>
   <div class="hero">
   <div class="controls" role="group" aria-label="Utility controls">
-    <div id="langContainer" class="lang-container">
+    <div class="lang-container">
       <label for="langSel" class="sr-only">Language</label>
       <select id="langSel" aria-label="Language">
-        <option value="en">EN</option>
-        <option value="es">ES</option>
-        <option value="fr">FR</option>
-        <option value="de">DE</option>
-        <option value="it">IT</option>
-        <option value="ru">RU</option>
+        <option value="en">🇺🇸 EN</option>
+        <option value="es">🇪🇸 ES</option>
+        <option value="fr">🇫🇷 FR</option>
+        <option value="de">🇩🇪 DE</option>
+        <option value="it">🇮🇹 IT</option>
+        <option value="ru">🇷🇺 RU</option>
       </select>
     </div>
     <button id="resetBtn" data-i18n="reset">Reset</button>
@@ -425,7 +401,6 @@
       modal.addEventListener('click', e=>{ if(e.target===modal) close(); });
       document.addEventListener('keydown', e=>{ if(e.key==='Escape' && !modal.classList.contains('hidden')) close(); });
     }
-    // (Flag decoration removed; simple language select retained)
   })();
   // Deferred mid-content ad insertion after 2nd category render
   (function(){
@@ -448,18 +423,15 @@
 <script type="module" src="./src/js/main.js"></script>
 <!-- (Removed custom lazy / retry script; using pure default one-line pushes above each ad) -->
 <script>
-  // Dynamically update <html lang> and flag icon when language changes
+  // Dynamically update <html lang> when language changes
   (function(){
     const sel = document.getElementById('langSel');
-    const container = document.getElementById('langContainer');
-    if(!sel || !container) return;
-    function applyLangAndFlag(){
-      const v = sel.value || 'en';
-      document.documentElement.setAttribute('lang', v);
-      container.className = 'lang-container ' + v; // Apply class to container
+    if(!sel) return;
+    function applyLang(){
+      document.documentElement.lang = sel.value || 'en';
     }
-    sel.addEventListener('change', applyLangAndFlag);
-    applyLangAndFlag(); // Initial setup
+    sel.addEventListener('change', applyLang);
+    applyLang(); // Initial setup
   })();
   // Basic fallback category headings for bots / no-JS (injection after slight delay if empty)
   (function(){


### PR DESCRIPTION
The previous implementation of the language selector flags used CSS background images with base64-encoded SVGs. This caused the flags to appear blurry and prevented them from being displayed in the dropdown options.

This commit replaces the CSS-based flags with Unicode emoji flags directly within the HTML `<option>` elements. This is a simpler, more robust solution that ensures the flags are rendered crisply and are visible in the dropdown menu.

The following changes were made:
- Modified `index.html` to add Unicode flag emojis to the language selector options.
- Removed the unnecessary CSS styles related to the old image-based flags.
- Removed the JavaScript code that dynamically added classes for the old flag implementation.