### PR TITLE
fix(webhook): remove problematic BUILD_ID placeholder from meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,7 @@
   <meta name="twitter:image" content="https://checklistsilksong.com/assets/images/ss_og_preview.png" />
   <!-- TODO: Add your Twitter handle here. Example: <meta name="twitter:site" content="@mytwitter" /> -->
   <!-- Optional: Provide Discord webhook endpoint at deploy time (se inyecta en CI; mantener vacío en el repo) -->
-  <!-- BUILD_TIMESTAMP_CACHE_BUST -->
-  <meta name="feedback-webhook" data-build-id="__BUILD_ID__" content="" />
+  <meta name="feedback-webhook" content="" />
 
   <!-- Preconnect & Performance Hints -->
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>


### PR DESCRIPTION
- Clean index.html to simple meta tag without data-build-id attribute
- Remove BUILD_TIMESTAMP_CACHE_BUST comment
- Should allow workflow regex to match and inject webhook properly