### PR TITLE
fix(webhook): simplify sed regex to match clean meta tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,8 @@ jobs:
           # Add cache busting comment to force CDN refresh
           sed -i "s|</head>|<!-- CDN-BUST: $CACHE_BUST -->\n</head>|" index.html
 
-          # Reemplazar la meta, aunque tenga espacios o se cierre con > o />
-          sed -i -E "s|<meta name=\"feedback-webhook\"[^>]*content=\"[^\"]*\"[^>]*>|<meta name=\"feedback-webhook\" content=\"$ESCAPED\" />|" index.html || echo 'Meta tag not found'
+          # Reemplazar la meta simple (sin atributos extra)
+          sed -i "s|<meta name=\"feedback-webhook\" content=\"\" />|<meta name=\"feedback-webhook\" content=\"$ESCAPED\" />|" index.html || echo 'Meta tag not found'
 
           # Verificar que realmente se inyectó
           MATCH_LINE=$(grep -n "feedback-webhook" index.html || true)


### PR DESCRIPTION
- Change complex regex to simple string replacement
- Match exact format: <meta name="feedback-webhook" content="" />
- Should now properly inject webhook URL into cleaned meta tag